### PR TITLE
fix typo in QuestionAdmin

### DIFF
--- a/aldryn_faq/admin.py
+++ b/aldryn_faq/admin.py
@@ -42,7 +42,7 @@ class QuestionAdmin(FrontendEditableAdminMixin, SortableAdmin, PlaceholderAdmin,
     render_placeholder_language_tabs = False
     list_display = ['__unicode__', 'category', 'is_top', 'number_of_visits']
     list_filter = ['category', 'translations__language_code']
-    frontend_editable_fields = ('title', 'category', 'answer_text'),
+    frontend_editable_fields = ('title', 'category', 'answer_text')
     readonly_fields = ['number_of_visits']
 
     def get_fieldsets(self, request, obj=None):


### PR DESCRIPTION
The comma makes `frontend_editable_fields` a tuple
