### PR TITLE
Adds questions to CMSAttachMenu to support breadcrumbs

### DIFF
--- a/aldryn_faq/tests/test_menu.py
+++ b/aldryn_faq/tests/test_menu.py
@@ -3,33 +3,31 @@
 from __future__ import unicode_literals
 
 from aldryn_faq.menu import FaqCategoryMenu
-from django.utils.translation import (
-    get_language_from_request,
-)
+
 from .test_base import AldrynFaqTest, CMSRequestBasedTest
 
 
 class TestMenu(AldrynFaqTest, CMSRequestBasedTest):
 
     def test_get_nodes(self):
-        # Test that the EN version of the menu has only category1 and is shown
-        # in English.
+        # Test that the EN version of the menu has only category1 and its
+        # question1, and is shown in English.
         request = self.get_page_request(None, self.user, '/en/')
         menu = FaqCategoryMenu()
         category1 = self.reload(self.category1, 'en')
+        question1 = self.reload(self.question1, 'en')
         self.assertEqualItems(
             [menuitem.title for menuitem in menu.get_nodes(request)],
-            [category1.name]
+            [category1.name, question1.title]
         )
 
-        # Test that the DE version has 2 categories and that they are shown in
-        # German.
+        # Test that the DE version has 2 categories and their questions that
+        # they are shown in German.
         request = self.get_page_request(None, self.user, '/de/')
         menu = FaqCategoryMenu()
-        category1 = self.reload(self.category1, 'de')
-        category2 = self.reload(self.category2, 'de')
         nodes = menu.get_nodes(request)
         self.assertEqualItems(
             [menuitem.title for menuitem in nodes],
-            [category1.name, category2.name]
+            [self.category1.name, self.category2.name, self.question1.title,
+                self.question2.title]
         )


### PR DESCRIPTION
Before this PR, breadcrumbs would not have worked correctly because the menus app (part of CMS), had no clue that the leaf nodes––categories and questions, which are actually apphook objects, not pages––even exist. By adding a CMSAttachMenu with all the categories and questions, the breadcrumb system works again.

HOWEVER, please note that during the testing of this, it was discovered that there is a serious bug in CMS 3.0.13 where the correct breadcrumbs would only appear in EITHER the published or draft version of the apphook, never both. This should be fixed in 3.0.14, or, you can pull this: https://github.com/divio/django-cms/archive/issues/fix_breadcrumbs.zip now.

ping: @vtay, @chronossc