### PR TITLE
Prevent possible future issues

### DIFF
--- a/aldryn_faq/managers.py
+++ b/aldryn_faq/managers.py
@@ -9,7 +9,7 @@ from parler.managers import TranslatableManager
 class RelatedManager(TranslatableManager):
 
     def filter_by_language(self, language):
-        return self.active_translations(language)
+        return self.active_translations(language_code=language).distinct()
 
     def filter_by_current_language(self):
         return self.filter_by_language(get_current_language())
@@ -18,7 +18,8 @@ class RelatedManager(TranslatableManager):
 class CategoryManager(TranslatableManager):
 
     def get_categories(self, language=None):
-        categories = self.active_translations(language).prefetch_related('questions')
+        categories = self.active_translations(
+            language_code=language).distinct().prefetch_related('questions')
 
         for category in categories:
             category.count = (category.questions

--- a/aldryn_faq/managers.py
+++ b/aldryn_faq/managers.py
@@ -9,7 +9,7 @@ from parler.managers import TranslatableManager
 class RelatedManager(TranslatableManager):
 
     def filter_by_language(self, language):
-        return self.active_translations(language_code=language).distinct()
+        return self.active_translations(language_code=language)
 
     def filter_by_current_language(self):
         return self.filter_by_language(get_current_language())
@@ -19,7 +19,7 @@ class CategoryManager(TranslatableManager):
 
     def get_categories(self, language=None):
         categories = self.active_translations(
-            language_code=language).distinct().prefetch_related('questions')
+            language_code=language).prefetch_related('questions')
 
         for category in categories:
             category.count = (category.questions


### PR DESCRIPTION
Explicitly use the kwarg name to eliminate ambiguity.