### PR TITLE
Fix warnings

### DIFF
--- a/aldryn_faq/forms.py
+++ b/aldryn_faq/forms.py
@@ -15,6 +15,11 @@ class CategoryAdminForm(TranslatableModelForm):
 
     class Meta:
         model = Category
+        fields = [
+            'name',
+            'slug',
+            'appconfig',
+        ]
 
     # def clean_slug(self):
     #     slug = self.cleaned_data['slug']
@@ -38,6 +43,9 @@ class QuestionListPluginForm(forms.ModelForm):
 
     class Meta:
         model = QuestionListPlugin
+        fields = [
+            'questions',
+        ]
 
     def __init__(self, *args, **kwargs):
         super(QuestionListPluginForm, self).__init__(*args, **kwargs)


### PR DESCRIPTION
```
/Users/finalangel/Sites/aldryn/aldryn-faq/aldryn_faq/forms.py:35: RemovedInDjango18Warning: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is deprecated - form QuestionListPluginForm needs updating
  class QuestionListPluginForm(forms.ModelForm):
```