### PR TITLE
adds working version of fallbacks

### DIFF
--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/question_list.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/question_list.html
@@ -31,6 +31,5 @@
 </div>
 
 {% if list and title %}
-    {% url 'aldryn_faq:faq-category' object.category.pk object.category.slug as category_url %}
-    {% include "aldryn_faq/includes/pager.html" with title=_("Back to Category") slug=category_url %}
+    {% include "aldryn_faq/includes/pager.html" with title=_("Back to Category") slug=object.category.get_absolute_ur %}
 {% endif %}

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/question_list.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/question_list.html
@@ -12,7 +12,7 @@
         {% endif %}
         <div class="list-group">
             {% for question in qgroup.list %}
-                <a href="{% url 'aldryn_faq:faq-answer' question.category.slug question.pk %}" class="list-group-item">
+                <a href="{{ question.get_absolute_url }}" class="list-group-item">
                     {% render_model question "title" %}
                     {% if not list %}<span class="badge">{{ qgroup.grouper }}</span>{% endif %}
                 </a>
@@ -31,6 +31,6 @@
 </div>
 
 {% if list and title %}
-    {% url 'aldryn_faq:faq-category' object.category.slug as category_url %}
+    {% url 'aldryn_faq:faq-category' object.category.pk object.category.slug as category_url %}
     {% include "aldryn_faq/includes/pager.html" with title=_("Back to Category") slug=category_url %}
 {% endif %}

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/ungrouped_question_list.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/ungrouped_question_list.html
@@ -3,7 +3,7 @@
 
 <div class="list-group">
     {% for question in object_list %}
-        <a href="{% url 'aldryn_faq:faq-answer' question.category.slug question.pk %}" class="list-group-item">
+        <a href="{{ question.get_absolute_url }}" class="list-group-item">
             {% render_model question "title" %}
         </a>
     {% empty %}

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/question_detail.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/question_detail.html
@@ -4,7 +4,7 @@
 {% block faq_content %}
     <article class="aldryn aldryn-faq aldryn-faq-detail">
         {% block faq_detail_categories %}
-            <a href="{% url 'aldryn_faq:faq-category' object.category.slug %}" class="label label-primary">
+            <a href="{{ category_url }}" class="label label-primary">
                 {% render_model object "category" "category" %}
             </a>
         {% endblock faq_detail_categories %}
@@ -30,7 +30,6 @@
 {% endblock %}
 
 {% block faq_footer %}
-    {% url 'aldryn_faq:faq-category' object.category.slug as category_url %}
     {% include "aldryn_faq/includes/pager.html" with title=_("Back to Category") slug=category_url %}
     {% static_placeholder "faq_detail_bottom" %}
 {% endblock %}

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/question_list.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/question_list.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block faq_footer %}
-    {% url 'aldryn_faq:faq-category-list' as category_url %}
-    {% include "aldryn_faq/includes/pager.html" with title=_("Back to Overview") slug=category_url %}
+    {% url 'aldryn_faq:faq-category-list' as category_list_url %}
+    {% include "aldryn_faq/includes/pager.html" with title=_("Back to Overview") slug=category_list_url %}
     {% render_placeholder view.config.placeholder_faq_list_bottom %}
 {% endblock %}

--- a/aldryn_faq/exceptions.py
+++ b/aldryn_faq/exceptions.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+
+class OldCategoryFormatUsed(Exception):
+    """
+    This exception is raised then we detect that the old url format for categories
+    is being used.
+    Once raised, this exception is handled by the view to redirect to the new
+    url format.
+    """
+    def __init__(self, category_slug, new_url_format):
+        self.category_slug = category_slug
+        self.new_url_format = new_url_format

--- a/aldryn_faq/exceptions.py
+++ b/aldryn_faq/exceptions.py
@@ -3,8 +3,8 @@
 
 class OldCategoryFormatUsed(Exception):
     """
-    This exception is raised then we detect that the old url format for categories
-    is being used.
+    This exception is raised then we detect
+    that the old url format for categories is being used.
     Once raised, this exception is handled by the view to redirect to the new
     url format.
     """

--- a/aldryn_faq/helpers.py
+++ b/aldryn_faq/helpers.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from django.shortcuts import _get_queryset
+
+from .exceptions import OldCategoryFormatUsed
+
+
+def get_category_from_slug(queryset, slug, pk=None, language=None):
+    """
+    Given a category queryset, lookup a category that matches
+    the given slug and pk if available.
+    If no pk is available or match is found by combining
+    slug and pk into one string, then raise OldCategoryFormatUsed exception.
+    """
+    if pk:
+        category = get_or_none(
+            queryset,
+            pk=pk,
+            translations__slug=slug
+        )
+
+        if category:
+            return category
+        else:
+            slug = '{}-{}'.format(pk, slug)
+
+    category = get_or_none(queryset, translations__slug=slug)
+
+    if category:
+        new_url = category.get_absolute_url(
+            language=language,
+            slug=slug
+        )
+        error = OldCategoryFormatUsed(
+            category_slug=slug,
+            new_url_format=new_url
+        )
+        raise error
+    return category
+
+
+def get_or_none(klass, *args, **kwargs):
+    queryset = _get_queryset(klass)
+
+    try:
+        return queryset.get(*args, **kwargs)
+    except queryset.model.DoesNotExist:
+        return None

--- a/aldryn_faq/managers.py
+++ b/aldryn_faq/managers.py
@@ -22,6 +22,6 @@ class CategoryManager(TranslatableManager):
             language_code=language).prefetch_related('questions')
 
         for category in categories:
-            questions = category.questions.all()
-            category.count = questions.filter_by_language(language).count()
+            questions_by_language = category.questions.filter_by_language
+            category.count = questions_by_language(language).count()
         return sorted(categories, key=lambda x: -x.count)

--- a/aldryn_faq/managers.py
+++ b/aldryn_faq/managers.py
@@ -22,6 +22,6 @@ class CategoryManager(TranslatableManager):
             language_code=language).prefetch_related('questions')
 
         for category in categories:
-            category.count = (category.questions
-            .filter_by_language(language).count())
+            questions = category.questions.all()
+            category.count = questions.filter_by_language(language).count()
         return sorted(categories, key=lambda x: -x.count)

--- a/aldryn_faq/menu.py
+++ b/aldryn_faq/menu.py
@@ -26,8 +26,9 @@ class FaqCategoryMenu(CMSAttachMenu):
 
         if hasattr(self, 'instance') and self.instance:
             #
-            # If self has a property `instance`, then we're using django CMS
-            # 3.0.12 or later, which supports using CMSAttachMenus on multiple,
+            # If self has a property `instance`
+            # then we're using django CMS 3.0.12 or later,
+            # which supports using CMSAttachMenus on multiple,
             # apphook'ed pages, each with their own apphook configuration. So,
             # here we modify the queryset to reflect this.
             #
@@ -37,15 +38,23 @@ class FaqCategoryMenu(CMSAttachMenu):
                 categories = categories.filter(appconfig=config)
 
         for category in categories:
+            category_name = category.safe_translation_getter(
+                'name',
+                language_code=language
+            )
             node = NavigationNode(
-                category.safe_translation_getter('name', language_code=language),
+                category_name,
                 category.get_absolute_url(language=language),
                 category.pk,
             )
             nodes.append(node)
             for question in category.questions.all():
+                question_title = question.safe_translation_getter(
+                    'title',
+                    language_code=language
+                )
                 node = NavigationNode(
-                    question.safe_translation_getter('title', language_code=language),
+                    question_title,
                     question.get_absolute_url(language=language),
                     # NOTE: We're adding 1 million here to avoid clashing with
                     # the category IDs.

--- a/aldryn_faq/models.py
+++ b/aldryn_faq/models.py
@@ -76,7 +76,7 @@ class Category(TranslationHelperMixin, TranslatableModel):
             language_code=language
         )
 
-        kwargs = {'category_slug': slug}
+        kwargs = {'category_pk': self.pk, 'category_slug': slug}
 
         if self.appconfig_id and self.appconfig.namespace:
             namespace = '{0}:'.format(self.appconfig.namespace)

--- a/aldryn_faq/models.py
+++ b/aldryn_faq/models.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import six
 
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -16,7 +15,7 @@ from aldryn_translation_tools.models import TranslationHelperMixin
 
 from cms.models.fields import PlaceholderField
 from cms.models.pluginmodel import CMSPlugin
-from cms.utils.i18n import get_current_language, get_fallback_languages
+from cms.utils.i18n import get_current_language
 
 from djangocms_text_ckeditor.fields import HTMLField
 from parler.models import TranslatableModel, TranslatedFields

--- a/aldryn_faq/models.py
+++ b/aldryn_faq/models.py
@@ -69,15 +69,16 @@ class Category(TranslationHelperMixin, TranslatableModel):
     def model_type_id(self):
         return ContentType.objects.get_for_model(self.__class__).id
 
-    def get_absolute_url(self, language=None):
+    def get_absolute_url(self, language=None, slug=None):
         if language is None:
             language = get_current_language()
 
-        slug = self.known_translation_getter(
-            'slug',
-            default=None,
-            language_code=language
-        )[0] or ''
+        if slug is None:
+            slug = self.known_translation_getter(
+                'slug',
+                default=None,
+                language_code=language
+            )[0] or ''
 
         kwargs = {'category_pk': self.pk, 'category_slug': slug}
 

--- a/aldryn_faq/search_indexes.py
+++ b/aldryn_faq/search_indexes.py
@@ -22,13 +22,15 @@ class QuestionIndex(get_index_base()):
             return obj.safe_translation_getter('title')
 
     def get_index_queryset(self, language):
-        return self.get_model().objects.language(language).active_translations(language)
+        questions = self.get_model().objects.language(language)
+        return questions.active_translations(language)
 
     def get_model(self):
         return Question
 
     def get_search_data(self, obj, language, request):
         with switch_language(obj, language):
+            context = RequestContext(request)
             text_bits = [
                 strip_tags(obj.safe_translation_getter('title') or ''),
                 strip_tags(obj.safe_translation_getter('answer_text') or '')
@@ -38,7 +40,7 @@ class QuestionIndex(get_index_base()):
                 instance, plugin_type = base_plugin.get_plugin_instance()
                 if instance is not None:
                     plugin_content = strip_tags(
-                        instance.render_plugin(context=RequestContext(request))
+                        instance.render_plugin(context=context)
                     )
                     text_bits.append(plugin_content)
 
@@ -57,7 +59,8 @@ class CategoryIndex(get_index_base()):
             return obj.safe_translation_getter('name')
 
     def get_index_queryset(self, language):
-        return self.get_model().objects.language(language).active_translations(language)
+        categories = self.get_model().objects.language(language)
+        return categories.active_translations(language)
 
     def get_model(self):
         return Category

--- a/aldryn_faq/tests/test_base.py
+++ b/aldryn_faq/tests/test_base.py
@@ -116,12 +116,18 @@ class AldrynFaqTestMixin(TestUtilityMixin, object):
             self.question1.save()
 
         # Make a DE translation of the category
-        self.mktranslation(self.category1, "de",
-            **self.data["category1"]["de"])
+        self.mktranslation(
+            self.category1,
+            "de",
+            **self.data["category1"]["de"]
+        )
 
         # Make a DE translation of the question
-        self.mktranslation(self.question1, "de",
-            **self.data["question1"]["de"])
+        self.mktranslation(
+            self.question1,
+            "de",
+            **self.data["question1"]["de"]
+        )
 
         with override("de"):
             # Make a DE-only Category
@@ -155,13 +161,21 @@ class CMSRequestBasedTest(TestUtilityMixin, TransactionTestCase):
         self.template = get_cms_setting('TEMPLATES')[0][0]
         self.language = settings.LANGUAGES[0][0]
         self.root_page = api.create_page(
-            'root page', self.template, self.language, published=True)
+            'root page',
+            self.template,
+            self.language,
+            published=True
+        )
         self.app_config = FaqConfig.objects.create(namespace='aldryn_faq')
-        self.page = api.create_page('faq', self.template, self.language,
+        self.page = api.create_page(
+            'faq',
+            self.template,
+            self.language,
             published=True,
             parent=self.root_page,
             apphook='FaqApp',
-            apphook_namespace=self.app_config.namespace)
+            apphook_namespace=self.app_config.namespace
+        )
         self.placeholder = self.page.placeholders.all()[0]
         self.request = get_request('en')
 

--- a/aldryn_faq/tests/test_i18n.py
+++ b/aldryn_faq/tests/test_i18n.py
@@ -27,7 +27,7 @@ class TestGetAbsoluteUrls(AldrynFaqTest):
         self.assertEquals('/de/faq/1-beispiel/', category_1_url)
         self.assertEquals('/de/faq/2-beispiel2/', category_2_url)
 
-        # Now, test that we can override the context with the language parameter
+        # test that we can override the context with the language parameter
         with override('en'):
             category_1_url = self.category1.get_absolute_url(language="de")
             category_2_url = self.category2.get_absolute_url(language="de")

--- a/aldryn_faq/tests/test_i18n.py
+++ b/aldryn_faq/tests/test_i18n.py
@@ -72,17 +72,24 @@ class TestGetAbsoluteUrls(AldrynFaqTest):
 
     def test_question_urls(self):
         question_1_pk = self.question1.pk
+        question_1_category_pk = self.question1.category_id
+
         question_2_pk = self.question2.pk
+        question_2_category_pk = self.question2.category_id
 
         with override('en'):
             question_1 = self.reload(self.question1)
             question_1_url = question_1.get_absolute_url()
 
             question_2 = self.reload(self.question2)
+
             question_2_url = question_2.get_absolute_url()
 
-        self.assertEquals('/en/faq/1-example/{pk}/'.format(pk=question_1_pk), question_1_url)
-        self.assertEquals('/en/faq/2-beispiel2/{pk}/'.format(pk=question_2_pk), question_2_url)
+        self.assertEquals('/en/faq/{cat_pk}-example/{pk}/'.format(
+            cat_pk=question_1_category_pk, pk=question_1_pk), question_1_url)
+
+        self.assertEquals('/en/faq/{cat_pk}-beispiel2/{pk}/'.format(
+            cat_pk=question_2_category_pk, pk=question_2_pk), question_2_url)
 
         with override('de'):
             question_1 = self.reload(self.question1)
@@ -91,8 +98,11 @@ class TestGetAbsoluteUrls(AldrynFaqTest):
             question_2 = self.reload(self.question2)
             question_2_url = question_2.get_absolute_url()
 
-        self.assertEquals('/de/faq/1-beispiel/{pk}/'.format(pk=question_1_pk), question_1_url)
-        self.assertEquals('/de/faq/2-beispiel2/{pk}/'.format(pk=question_2_pk), question_2_url)
+        self.assertEquals('/de/faq/{cat_pk}-beispiel/{pk}/'.format(
+            cat_pk=question_1_category_pk, pk=question_1_pk), question_1_url)
+
+        self.assertEquals('/de/faq/{cat_pk}-beispiel2/{pk}/'.format(
+            cat_pk=question_2_category_pk, pk=question_2_pk), question_2_url)
 
     def test_question_urls_fallbacks(self):
         question_1 = self.question1

--- a/aldryn_faq/tests/test_i18n.py
+++ b/aldryn_faq/tests/test_i18n.py
@@ -11,38 +11,48 @@ from .test_base import AldrynFaqTest
 class TestGetAbsoluteUrls(AldrynFaqTest):
 
     def test_category_urls(self):
+        category_1_pk = self.category1.pk
+        category_2_pk = self.category2.pk
 
         with override('en'):
             category_1_url = self.category1.get_absolute_url()
             category_2_url = self.category2.get_absolute_url()
 
-        self.assertEquals('/en/faq/1-example/', category_1_url)
+        self.assertEquals('/en/faq/{cat}-example/'.format(
+            cat=category_1_pk), category_1_url)
         # category2 doesn't exist EN, so this should fallback to DE
-        self.assertEquals('/en/faq/2-beispiel2/', category_2_url)
+        self.assertEquals('/en/faq/{cat}-beispiel2/'.format(
+            cat=category_2_pk), category_2_url)
 
         with override('de'):
             category_1_url = self.category1.get_absolute_url()
             category_2_url = self.category2.get_absolute_url()
 
-        self.assertEquals('/de/faq/1-beispiel/', category_1_url)
-        self.assertEquals('/de/faq/2-beispiel2/', category_2_url)
+        self.assertEquals('/de/faq/{cat}-beispiel/'.format(
+            cat=category_1_pk), category_1_url)
+        self.assertEquals('/de/faq/{cat}-beispiel2/'.format(
+            cat=category_2_pk), category_2_url)
 
         # test that we can override the context with the language parameter
         with override('en'):
             category_1_url = self.category1.get_absolute_url(language="de")
             category_2_url = self.category2.get_absolute_url(language="de")
 
-        self.assertEquals('/de/faq/1-beispiel/', category_1_url)
-        self.assertEquals('/de/faq/2-beispiel2/', category_2_url)
+        self.assertEquals('/de/faq/{cat}-beispiel/'.format(
+            cat=category_1_pk), category_1_url)
+        self.assertEquals('/de/faq/{cat}-beispiel2/'.format(
+            cat=category_2_pk), category_2_url)
 
         # For completeness, do the other way too
         with override('de'):
             category_1_url = self.category1.get_absolute_url(language="en")
             category_2_url = self.category2.get_absolute_url(language="en")
 
-        self.assertEquals('/en/faq/1-example/', category_1_url)
+        self.assertEquals('/en/faq/{cat}-example/'.format(
+            cat=category_1_pk), category_1_url)
         # category2 doesn't exist EN, so this should fallback to DE
-        self.assertEquals('/en/faq/2-beispiel2/', category_2_url)
+        self.assertEquals('/en/faq/{cat}-beispiel2/'.format(
+            cat=category_2_pk), category_2_url)
 
     def test_category_urls_fallbacks(self):
         category_1 = self.category1
@@ -53,7 +63,7 @@ class TestGetAbsoluteUrls(AldrynFaqTest):
         # this should fallback to the german category
         self.assertEqual(
             category_2.get_absolute_url("en"),
-            "/en/faq/2-beispiel2/"
+            "/en/faq/{cat}-beispiel2/".format(cat=category_2.pk)
         )
 
         # category 1 is not translated in french
@@ -61,7 +71,7 @@ class TestGetAbsoluteUrls(AldrynFaqTest):
         # this should fallback to the english category
         self.assertEqual(
             category_1.get_absolute_url("fr"),
-            "/fr/faq/1-example/"
+            "/fr/faq/{cat}-example/".format(cat=category_1.pk)
         )
 
         with self.assertRaises(NoReverseMatch):
@@ -106,17 +116,20 @@ class TestGetAbsoluteUrls(AldrynFaqTest):
 
     def test_question_urls_fallbacks(self):
         question_1 = self.question1
-        question_1_pk = self.question1.pk
+        question_1_pk = question_1.pk
+        question_1_category_pk = question_1.category_id
 
         question_2 = self.question2
-        question_2_pk = self.question2.pk
+        question_2_pk = question_2.pk
+        question_2_category_pk = question_2.category_id
 
         # question 2 is not translated in english
         # so given our test fallback config
         # this should fallback to the german category
         self.assertEqual(
             question_2.get_absolute_url("en"),
-            "/en/faq/2-beispiel2/{pk}/".format(pk=question_2_pk)
+            "/en/faq/{cat_pk}-beispiel2/{pk}/".format(
+                cat_pk=question_2_category_pk, pk=question_2_pk)
         )
 
         # question 1 is not translated in french
@@ -124,7 +137,8 @@ class TestGetAbsoluteUrls(AldrynFaqTest):
         # this should fallback to the english category
         self.assertEqual(
             question_1.get_absolute_url("fr"),
-            "/fr/faq/1-example/{pk}/".format(pk=question_1_pk)
+            "/fr/faq/{cat_pk}-example/{pk}/".format(
+                cat_pk=question_1_category_pk, pk=question_1_pk)
         )
 
         with self.assertRaises(NoReverseMatch):

--- a/aldryn_faq/tests/test_models.py
+++ b/aldryn_faq/tests/test_models.py
@@ -209,22 +209,25 @@ class TestFAQTranslations(AldrynFaqTest):
         # we expect to fallback to english
         with override("fr"):
             question_1_fr = self.reload(self.question1)
+            question_1_fr_translation = question_1_fr.safe_translation_getter
+
             category_1_fr = self.reload(self.question1.category)
+            category_1_fr_translation = category_1_fr.safe_translation_getter
 
             self.assertEqual(
-                question_1_fr.safe_translation_getter('title', any_language=True),
+                question_1_fr_translation('title', any_language=True),
                 self.data["question1"]["en"]["title"]
             )
             self.assertEqual(
-                question_1_fr.safe_translation_getter('answer_text', any_language=True),
+                question_1_fr_translation('answer_text', any_language=True),
                 self.data["question1"]["en"]["answer_text"]
             )
             self.assertEqual(
-                category_1_fr.safe_translation_getter('name', any_language=True),
+                category_1_fr_translation('name', any_language=True),
                 self.data["category1"]["en"]["name"]
             )
             self.assertEqual(
-                category_1_fr.safe_translation_getter('slug', any_language=True),
+                category_1_fr_translation('slug', any_language=True),
                 self.data["category1"]["en"]["slug"]
             )
 
@@ -232,21 +235,24 @@ class TestFAQTranslations(AldrynFaqTest):
         # we expect to fallback to german
         with override("en"):
             question_2_en = self.reload(self.question2)
+            question_2_en_translation = question_2_en.safe_translation_getter
+
             category_2_en = self.reload(self.question2.category)
+            category_2_en_translation = category_2_en.safe_translation_getter
 
             self.assertEqual(
-                question_2_en.safe_translation_getter('title', any_language=True),
+                question_2_en_translation('title', any_language=True),
                 self.data["question2"]["de"]["title"]
             )
             self.assertEqual(
-                question_2_en.safe_translation_getter('answer_text', any_language=True),
+                question_2_en_translation('answer_text', any_language=True),
                 self.data["question2"]["de"]["answer_text"]
             )
             self.assertEqual(
-                category_2_en.safe_translation_getter('name', any_language=True),
+                category_2_en_translation('name', any_language=True),
                 self.data["category2"]["de"]["name"]
             )
             self.assertEqual(
-                category_2_en.safe_translation_getter('slug', any_language=True),
+                category_2_en_translation('slug', any_language=True),
                 self.data["category2"]["de"]["slug"]
             )

--- a/aldryn_faq/tests/test_models.py
+++ b/aldryn_faq/tests/test_models.py
@@ -48,11 +48,11 @@ class TestCategory(AldrynFaqTest):
 
         self.assertEqual(
             category_1.get_absolute_url("en"),
-            "/en/faq/1-example/"
+            "/en/faq/{pk}-example/".format(pk=category_1.pk)
         )
         self.assertEqual(
             category_1.get_absolute_url("de"),
-            "/de/faq/1-beispiel/"
+            "/de/faq/{pk}-beispiel/".format(pk=category_1.pk)
         )
 
     def test_manager_get_categories(self):
@@ -105,15 +105,24 @@ class TestQuestion(AldrynFaqTest):
         )
 
     def test_get_absolue_url(self):
+        category_pk = self.question1.category_id
         question_1_pk = self.question1.pk
+        question_1_url_en = "/en/faq/{cat_pk}-example/{pk}/".format(
+            cat_pk=category_pk,
+            pk=question_1_pk
+        )
+        question_1_url_de = "/de/faq/{cat_pk}-beispiel/{pk}/".format(
+            cat_pk=category_pk,
+            pk=question_1_pk
+        )
 
         self.assertEqual(
             self.question1.get_absolute_url("en"),
-            "/en/faq/1-example/{pk}/".format(pk=question_1_pk)
+            question_1_url_en
         )
         self.assertEqual(
             self.question1.get_absolute_url("de"),
-            "/de/faq/1-beispiel/{pk}/".format(pk=question_1_pk)
+            question_1_url_de
         )
 
     def test_manager_filter_by_language(self):

--- a/aldryn_faq/tests/test_sitemaps.py
+++ b/aldryn_faq/tests/test_sitemaps.py
@@ -11,10 +11,14 @@ class TestSitemap(AldrynFaqTest):
 
     def test_categories_sitemap_items(self):
         categories = [cat.id for cat in FAQCategoriesSitemap().items()]
-        self.assertEqualItems(categories,
-            [self.category1.id, self.category2.id])
+        self.assertEqualItems(
+            categories,
+            [self.category1.id, self.category2.id]
+        )
 
     def test_questions_sitemap_items(self):
         questions = [que.id for que in FAQQuestionsSitemap().items()]
-        self.assertEqualItems(questions,
-            [self.question1.id, self.question2.id])
+        self.assertEqualItems(
+            questions,
+            [self.question1.id, self.question2.id]
+        )

--- a/aldryn_faq/tests/test_views.py
+++ b/aldryn_faq/tests/test_views.py
@@ -2,6 +2,11 @@
 
 from __future__ import unicode_literals
 
+try:
+    from imp import reload
+except ImportError:
+    from importlib import reload
+
 from django.core.urlresolvers import resolve, reverse
 from django.http import Http404
 from django.utils.translation import override

--- a/aldryn_faq/tests/test_views.py
+++ b/aldryn_faq/tests/test_views.py
@@ -87,7 +87,9 @@ class TestFaqByCategoryView(AldrynFaqTest):
         kwargs = {"category_slug": category_1.slug}
 
         with override('en'):
-            category_1_url_name = '{0}:faq-category'.format(self.app_config.namespace)
+            category_1_url_name = '{ns}:faq-category'.format(
+                ns=self.app_config.namespace
+            )
             category_1_url_old = reverse(category_1_url_name, kwargs=kwargs)
 
         request = self.get_page_request(
@@ -164,7 +166,7 @@ class TestFaqAnswerView(AldrynFaqTest):
         }
 
         with override('en'):
-            url_name = '{0}:faq-answer'.format(self.app_config.namespace)
+            url_name = '{ns}:faq-answer'.format(ns=self.app_config.namespace)
             question_1_url_old = reverse(url_name, kwargs=kwargs)
 
         request = self.get_page_request(
@@ -193,7 +195,7 @@ class TestFaqAnswerView(AldrynFaqTest):
         }
 
         with override('de'):
-            url_name = '{0}:faq-answer'.format(self.app_config.namespace)
+            url_name = '{ns}:faq-answer'.format(ns=self.app_config.namespace)
             question_2_invalid_url = reverse(url_name, kwargs=kwargs)
 
         request = self.get_page_request(

--- a/aldryn_faq/tests/urls.py
+++ b/aldryn_faq/tests/urls.py
@@ -12,7 +12,8 @@ from cms.utils.conf import get_cms_setting
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
     url(
         r'^media/(?P<path>.*)$', 'django.views.static.serve', {
             'document_root': settings.MEDIA_ROOT, 'show_indexes': True

--- a/aldryn_faq/tests/urls.py
+++ b/aldryn_faq/tests/urls.py
@@ -19,8 +19,11 @@ urlpatterns = patterns('',
         }
     ),
     url(
-        r'^media/cms/(?P<path>.*)$', 'django.views.static.serve', {
-            'document_root': get_cms_setting('MEDIA_ROOT'), 'show_indexes': True
+        r'^media/cms/(?P<path>.*)$',
+        'django.views.static.serve',
+        {
+            'document_root': get_cms_setting('MEDIA_ROOT'),
+            'show_indexes': True
         }
     ),
     url(
@@ -29,10 +32,12 @@ urlpatterns = patterns('',
     ),
 )
 
-urlpatterns += staticfiles_urlpatterns()
-
-urlpatterns += i18n_patterns('',
+url_i18n_patterns = i18n_patterns('',
     url(r'^admin/', include(admin.site.urls)),
     url(r'^faq/', include('aldryn_faq.urls', namespace='aldryn_faq')),
     url(r'^', include('cms.urls')),
 )
+
+urlpatterns += staticfiles_urlpatterns()
+
+urlpatterns += url_i18n_patterns

--- a/aldryn_faq/urls.py
+++ b/aldryn_faq/urls.py
@@ -24,4 +24,9 @@ urlpatterns = patterns('',
         FaqAnswerView.as_view(),
         name='faq-answer'
     ),
+    url(
+        r'^(?P<category_pk>[0-9]+)/(?P<category_slug>[-\w]+)/(?P<pk>[0-9]+)/$',
+        FaqAnswerView.as_view(),
+        name='faq-answer'
+    ),
 )

--- a/aldryn_faq/urls.py
+++ b/aldryn_faq/urls.py
@@ -15,6 +15,11 @@ urlpatterns = patterns('',
         name='faq-category'
     ),
     url(
+        r'^(?P<category_pk>[0-9]+)/(?P<category_slug>[-\w]+)/$',
+        FaqByCategoryView.as_view(),
+        name='faq-category'
+    ),
+    url(
         r'^(?P<category_slug>[-\w]+)/(?P<pk>[0-9]+)/$',
         FaqAnswerView.as_view(),
         name='faq-answer'

--- a/aldryn_faq/urls.py
+++ b/aldryn_faq/urls.py
@@ -10,22 +10,22 @@ from .views import FaqAnswerView, FaqByCategoryView, FaqByCategoryListView
 urlpatterns = patterns('',
     url(r'^$', FaqByCategoryListView.as_view(), name='faq-category-list'),
     url(
+        r'^(?P<category_pk>[0-9]+)-(?P<category_slug>[-\w]+)/$',
+        FaqByCategoryView.as_view(),
+        name='faq-category'
+    ),
+    url(
+        r'^(?P<category_pk>[0-9]+)-(?P<category_slug>[-\w]+)/(?P<pk>[0-9]+)/$',
+        FaqAnswerView.as_view(),
+        name='faq-answer'
+    ),
+    url(
         r'^(?P<category_slug>[-\w]+)/$',
         FaqByCategoryView.as_view(),
         name='faq-category'
     ),
     url(
-        r'^(?P<category_pk>[0-9]+)/(?P<category_slug>[-\w]+)/$',
-        FaqByCategoryView.as_view(),
-        name='faq-category'
-    ),
-    url(
         r'^(?P<category_slug>[-\w]+)/(?P<pk>[0-9]+)/$',
-        FaqAnswerView.as_view(),
-        name='faq-answer'
-    ),
-    url(
-        r'^(?P<category_pk>[0-9]+)/(?P<category_slug>[-\w]+)/(?P<pk>[0-9]+)/$',
         FaqAnswerView.as_view(),
         name='faq-answer'
     ),

--- a/aldryn_faq/views.py
+++ b/aldryn_faq/views.py
@@ -75,8 +75,8 @@ class FaqByCategoryView(FaqMixin, TranslatableSlugMixin, ListView):
 
         self.category = self.get_object(queryset=categories)
         setattr(self.request, request_faq_category_identifier, self.category)
-        response = super(FaqByCategoryView, self).get(*args, **kwargs)
         set_language_changer(self.request, self.category.get_absolute_url)
+        response = super(FaqByCategoryView, self).get(*args, **kwargs)
         return response
 
     def get_slug_field(self):

--- a/aldryn_faq/views.py
+++ b/aldryn_faq/views.py
@@ -68,6 +68,11 @@ class FaqByCategoryView(FaqMixin, TranslatableSlugMixin, ListView):
 
     def get(self, *args, **kwargs):
         categories = self.get_category_queryset()
+        category_pk = kwargs.get('category_pk')
+
+        if category_pk:
+            categories = categories.filter(pk=category_pk)
+
         self.category = self.get_object(queryset=categories)
         setattr(self.request, request_faq_category_identifier, self.category)
         response = super(FaqByCategoryView, self).get(*args, **kwargs)

--- a/aldryn_faq/views.py
+++ b/aldryn_faq/views.py
@@ -174,6 +174,8 @@ class FaqAnswerView(FaqCategoryMixin, DetailView):
 
     def get_object(self, queryset=None):
         if not hasattr(self, '_object'):
+            # this is done because this method gets called twice.
+            # so no need to query db twice.
             self._object = super(FaqAnswerView, self).get_object(queryset)
         return self._object
 

--- a/aldryn_faq/views.py
+++ b/aldryn_faq/views.py
@@ -141,7 +141,8 @@ class FaqAnswerView(FaqCategoryMixin, DetailView):
             # /en/faq/category-en/
             # /de/faq/category-de/
             # with this check we make sure that any request to
-            # /en/faq/category-de/10/ gets redirected to /en/faq/category-en/10/
+            # /en/faq/category-de/10/ gets redirected
+            # to /en/faq/category-en/10/
             # where 10 is the question id
             return HttpResponsePermanentRedirect(question_url)
 

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -1,7 +1,7 @@
 aldryn-apphooks-config
 aldryn-boilerplates
 aldryn-reversion
-aldryn_translation_tools
+aldryn_translation_tools>=0.0.5,<0.0.7
 coverage==3.7.1
 python-coveralls>=2.4.2
 django-admin-sortable2>=0.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -32,5 +32,5 @@ deps =
     coveralls
 
 [testenv:pep8]
-commands = pep8 --repeat --show-source --max-line-length=79 --exclude=env,.tox,dist,migrations,migrations_django aldryn_faq setup.py
+commands = pep8 --repeat --show-source --max-line-length=79 --exclude=env,.tox,dist,migrations,south_migrations,migrations_django aldryn_faq setup.py
 deps = pep8


### PR DESCRIPTION
**New url format**

In order to correctly support fallbacks, we needed to rethink the current url format.

Currently, the url formats are:

*/en/faq/{category_slug}/*
*/en/faq/{category_slug}/{question_id}/*

This format can cause problems when fallbacks are enabled, for example:

**Category 1 (en & fr)**
*/en/faq/queue/*
*/fr/faq/file/*

**Category 2 (en)**
*/en/faq/file/*

If a user visits ```/en/faq/file/```, category 2 will be served.
This is expected because it's an exact match of it's slug, if the user uses the language chooser
to go to the french version of this category (with fallbacks) the url will be ```/fr/faq/file/``` which is correct in syntax **but** when visited will cause Category 1 to be rendered because it's an exact match of it's french slug.
This can be quite confusing to users and so would not work for us.

So we've changed the url formats to:

*/en/faq/{category_id}-{category_slug}/*
*/en/faq/{category_id}-{category_slug}/{question_id}/*

this would then allow us to target a specific category when building it's url using the language chooser.

Breaking backwards compatibility is not an option, so with this in mind, we've made sure that the old urls will resolve to it's new format and return an http permanent redirect.

**Fallback Scenarios**

**Category 1 (en & de)**
*/en/faq/category-1-en/*
*/de/faq/category-1-de/*

If user requests ```/en/faq/category-1-de/``` then he will be redirected to ```/en/faq/category-1-en/```
if user requests ```/en/faq/category-1-de/10/``` then he will be redirected to ```/en/faq/category-1-en/10/```

**Category 2 (de)**
*/de/faq/category-1-de/*

If user requests ```/en/faq/category-1-de/``` then he will stay in this page as long as fallbacks are enabled, otherwise a 404 will be raised.
if user requests ```/en/faq/category-1-de/10/``` then he will stay in this page then he will stay in this page as long as fallbacks are enabled, otherwise a 404 will be raised.
