### PR TITLE
Added faq block creation and question deletion tests

### DIFF
--- a/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
+++ b/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
@@ -38,7 +38,7 @@ var faqPage = {
     // adding new apphook config
     breadcrumbsLinks: element.all(by.css('.breadcrumbs a')),
     faqConfigsLink: element(by.css('.model-faqconfig > th > a')),
-    editConfigsLink: element(by.css('.row1 > th > a')),
+    editConfigsLink: element(by.css('.row1 th > a')),
     addConfigsButton: element(by.css('.object-tools .addlink')),
     namespaceInput: element(by.id('id_namespace')),
     applicationTitleInput: element(by.id('id_app_title')),
@@ -58,6 +58,17 @@ var faqPage = {
     saveAndContinueButton: element(by.css('.submit-row [name="_continue"]')),
     editQuestionLinks: element.all(by.css(
         '.results [href*="/aldryn_faq/question/"]')),
+
+    // adding faq block to the page
+    aldrynFAQBlock: element(by.css('.aldryn-faq-categories')),
+    advancedSettingsOption: element(by.css(
+        '.cms_toolbar-item-navigation [href*="advanced-settings"]')),
+    modalIframe: element(by.css('.cms_modal-frame iframe')),
+    applicationSelect: element(by.id('application_urls')),
+    saveModalButton: element(by.css('.cms_modal-buttons .cms_btn-action')),
+    categoryLink: element(by.css('.aldryn-faq-categories a')),
+    questionLink: element(by.css('.aldryn-faq .list-group a')),
+    questionTitle: element(by.css('.aldryn-faq-detail h2 > div')),
 
     cmsLogin: function (credentials) {
         // object can contain username and password, if not set it will

--- a/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
+++ b/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
@@ -57,7 +57,7 @@ var faqPage = {
     ckeEditableBlock: element(by.css('.cke_editable')),
     saveAndContinueButton: element(by.css('.submit-row [name="_continue"]')),
     editQuestionLinks: element.all(by.css(
-        '.results .field-__str__ > [href*="/aldryn_faq/question/"]')),
+        '.results th > [href*="/aldryn_faq/question/"]')),
 
     // adding faq block to the page
     aldrynFAQBlock: element(by.css('.aldryn-faq-categories')),

--- a/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
+++ b/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
@@ -57,7 +57,7 @@ var faqPage = {
     ckeEditableBlock: element(by.css('.cke_editable')),
     saveAndContinueButton: element(by.css('.submit-row [name="_continue"]')),
     editQuestionLinks: element.all(by.css(
-        '.results [href*="/aldryn_faq/question/"]')),
+        '.results .field-__str__ > [href*="/aldryn_faq/question/"]')),
 
     // adding faq block to the page
     aldrynFAQBlock: element(by.css('.aldryn-faq-categories')),
@@ -69,6 +69,10 @@ var faqPage = {
     categoryLink: element(by.css('.aldryn-faq-categories a')),
     questionLink: element(by.css('.aldryn-faq .list-group a')),
     questionTitle: element(by.css('.aldryn-faq-detail h2 > div')),
+
+    // deleting question
+    deleteButton: element(by.css('.deletelink-box a')),
+    sidebarConfirmationButton: element(by.css('#content [type="submit"]')),
 
     cmsLogin: function (credentials) {
         // object can contain username and password, if not set it will

--- a/aldryn_faq/tests/frontend/integration/specs/spec.faq.crud.js
+++ b/aldryn_faq/tests/frontend/integration/specs/spec.faq.crud.js
@@ -46,7 +46,7 @@ describe('Aldryn FAQ tests: ', function () {
                 return browser.isElementPresent(faqPage.userMenuDropdown);
             }, faqPage.mainElementsWaitTime);
 
-            faqPage.administrationOptions.first().click();
+            return faqPage.administrationOptions.first().click();
         }).then(function () {
             // wait for modal iframe to appear
             browser.wait(function () {
@@ -62,6 +62,11 @@ describe('Aldryn FAQ tests: ', function () {
             }, faqPage.mainElementsWaitTime);
 
             faqPage.pagesLink.click();
+
+            // wait for iframe side menu to reload
+            browser.wait(function () {
+                return browser.isElementPresent(faqPage.addConfigsButton);
+            }, faqPage.mainElementsWaitTime);
 
             // check if the page already exists and return the status
             return faqPage.addPageLink.isPresent();
@@ -181,6 +186,11 @@ describe('Aldryn FAQ tests: ', function () {
 
         faqPage.categoriesLink.click();
 
+        // wait for iframe side menu to reload
+        browser.wait(function () {
+            return browser.isElementPresent(faqPage.addConfigsButton);
+        }, faqPage.mainElementsWaitTime);
+
         // check if the category already exists and return the status
         faqPage.editConfigsLink.isPresent().then(function (present) {
             if (present === false) {
@@ -254,8 +264,8 @@ describe('Aldryn FAQ tests: ', function () {
             faqPage.categorySelect.click();
             return faqPage.categorySelect.sendKeys('Test category');
         }).then(function () {
-            faqPage.categorySelect.click();
-
+            return faqPage.categorySelect.click();
+        }).then(function () {
             // wait for cke iframe to appear
             browser.wait(function () {
                 return browser.isElementPresent(faqPage.ckeIframe);
@@ -296,11 +306,83 @@ describe('Aldryn FAQ tests: ', function () {
             }, faqPage.mainElementsWaitTime);
 
             // validate success notification
-            expect(faqPage.successNotification.isDisplayed())
-                .toBeTruthy();
+            expect(faqPage.successNotification.isDisplayed()).toBeTruthy();
             // validate edit question link
             expect(faqPage.editQuestionLinks.first().isDisplayed())
                 .toBeTruthy();
+        });
+    });
+
+    it('adds a new faq block on the page', function () {
+        // switch to default page content
+        browser.switchTo().defaultContent();
+
+        // add faq to the page only if it was not added before
+        faqPage.aldrynFAQBlock.isPresent().then(function (present) {
+            if (present === false) {
+                // click the Page link in the top menu
+                return faqPage.userMenus.get(1).click().then(function () {
+                    // wait for top menu dropdown options to appear
+                    browser.wait(function () {
+                        return browser.isElementPresent(faqPage.userMenuDropdown);
+                    }, faqPage.mainElementsWaitTime);
+
+                    faqPage.advancedSettingsOption.click();
+
+                    // wait for modal iframe to appear
+                    browser.wait(function () {
+                        return browser.isElementPresent(faqPage.modalIframe);
+                    }, faqPage.iframeWaitTime);
+
+                    // switch to modal iframe
+                    browser.switchTo().frame(browser.findElement(By.css(
+                        '.cms_modal-frame iframe')));
+
+                    // wait for Application select to appear
+                    browser.wait(function () {
+                        return browser.isElementPresent(faqPage.applicationSelect);
+                    }, faqPage.mainElementsWaitTime);
+
+                    // set Application
+                    faqPage.applicationSelect.click();
+                    faqPage.applicationSelect.sendKeys('FAQ')
+                        .then(function () {
+                        faqPage.applicationSelect.click();
+                    });
+
+                    // switch to default page content
+                    browser.switchTo().defaultContent();
+
+                    browser.wait(function () {
+                        return browser.isElementPresent(faqPage.saveModalButton);
+                    }, faqPage.mainElementsWaitTime);
+
+                    browser.actions().mouseMove(faqPage.saveModalButton)
+                        .perform();
+                    return faqPage.saveModalButton.click();
+                });
+            }
+        }).then(function () {
+            // wait for aldryn-faq block to appear
+            browser.wait(function () {
+                return browser.isElementPresent(faqPage.aldrynFAQBlock);
+            }, faqPage.mainElementsWaitTime);
+
+            faqPage.categoryLink.click();
+
+            // wait for question link to appear
+            browser.wait(function () {
+                return browser.isElementPresent(faqPage.questionLink);
+            }, faqPage.mainElementsWaitTime);
+
+            faqPage.questionLink.click();
+
+            browser.wait(function () {
+                return browser.isElementPresent(faqPage.questionTitle);
+            }, faqPage.mainElementsWaitTime);
+
+            // validate question title
+            expect(faqPage.questionTitle.isDisplayed()).toBeTruthy();
         });
     });
 

--- a/aldryn_faq/tests/frontend/integration/specs/spec.faq.crud.js
+++ b/aldryn_faq/tests/frontend/integration/specs/spec.faq.crud.js
@@ -386,4 +386,71 @@ describe('Aldryn FAQ tests: ', function () {
         });
     });
 
+    it('deletes question', function () {
+        // wait for modal iframe to appear
+        browser.wait(function () {
+            return browser.isElementPresent(faqPage.sideMenuIframe);
+        }, faqPage.iframeWaitTime);
+
+        // switch to sidebar menu iframe
+        browser.switchTo()
+            .frame(browser.findElement(By.css('.cms_sideframe-frame iframe')));
+
+        // wait for edit question link to appear
+        browser.wait(function () {
+            return browser.isElementPresent(faqPage.editQuestionLinks.first());
+        }, faqPage.mainElementsWaitTime);
+
+        // validate edit question links texts to delete proper question
+        faqPage.editQuestionLinks.first().getText().then(function (text) {
+            if (text === questionName) {
+                return faqPage.editQuestionLinks.first().click();
+            } else {
+                faqPage.editQuestionLinks.get(1).getText()
+                    .then(function (text) {
+                    if (text === questionName) {
+                        return faqPage.editQuestionLinks.get(1).click();
+                    } else {
+                        faqPage.editQuestionLinks.get(2).getText()
+                            .then(function (text) {
+                            if (text === questionName) {
+                                return faqPage.editQuestionLinks.get(2).click();
+                            }
+                        });
+                    }
+                });
+            }
+        }).then(function () {
+            // wait for delete button to appear
+            browser.wait(function () {
+                return browser.isElementPresent(faqPage.deleteButton);
+            }, faqPage.mainElementsWaitTime);
+
+            browser.actions().mouseMove(faqPage.saveAndContinueButton)
+                .perform();
+            return faqPage.deleteButton.click();
+        }).then(function () {
+            // wait for confirmation button to appear
+            browser.wait(function () {
+                return browser.isElementPresent(faqPage.sidebarConfirmationButton);
+            }, faqPage.mainElementsWaitTime);
+
+            faqPage.sidebarConfirmationButton.click();
+
+            browser.wait(function () {
+                return browser.isElementPresent(faqPage.successNotification);
+            }, faqPage.mainElementsWaitTime);
+
+            // validate success notification
+            expect(faqPage.successNotification.isDisplayed())
+                .toBeTruthy();
+
+            // switch to default page content
+            browser.switchTo().defaultContent();
+
+            // refresh the page to see changes
+            browser.refresh();
+        });
+    });
+
 });


### PR DESCRIPTION
**This pull request adds faq block creation and question deletion tests**

Also:
- updated ```return```
- **known issue**: phantomjs fails for Aldryn FAQ tests: creates a new question - apparently because of iframe switching. Works ok on Chrome and Firefox
- **known issue**: some tests will fail as ```aldryn_apphook_reload``` is not configured yet