### PR TITLE
Update test settings to be appropriate for djangocms-helper>0.9.1

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 HAYSTACK_CONNECTIONS = {
     'default': {
@@ -35,8 +36,6 @@ HELPER_SETTINGS = {
     'INSTALLED_APPS': [
         'adminsortable2',
         'aldryn_apphook_reload',
-        'aldryn_boilerplates',
-        'aldryn_faq',
         'aldryn_reversion',
         'aldryn_translation_tools',
         'djangocms_text_ckeditor',
@@ -63,19 +62,6 @@ HELPER_SETTINGS = {
         'cms.middleware.page.CurrentPageMiddleware',
         'cms.middleware.toolbar.ToolbarMiddleware',
         'cms.middleware.language.LanguageCookieMiddleware'
-    ],
-    'STATICFILES_FINDERS': [
-        'django.contrib.staticfiles.finders.FileSystemFinder',
-        # important! place right before django.contrib.staticfiles.finders.AppDirectoriesFinder  # NOQA
-        'aldryn_boilerplates.staticfile_finders.AppDirectoriesFinder',
-        'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    ],
-    'TEMPLATE_LOADERS': [
-        'django.template.loaders.filesystem.Loader',
-        # important! place right before django.template.loaders.app_directories.Loader  # NOQA
-        'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',
-        'django.template.loaders.app_directories.Loader',
-        'django.template.loaders.eggs.Loader',
     ],
     'ALDRYN_BOILERPLATE_NAME': 'bootstrap3',
     'HAYSTACK_CONNECTIONS': HAYSTACK_CONNECTIONS,
@@ -118,7 +104,7 @@ HELPER_SETTINGS = {
 
 def run():
     from djangocms_helper import runner
-    runner.cms('aldryn_faq')
+    runner.cms('aldryn_faq', extra_args=['--boilerplate'])
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
* Use unicode literals in test_settings,
* Use features of ``djangocms-helper`` instead of explicit configuration of ``aldryn-boilerplates``.

Packages are removed from installed apps because by default ``djangocms-helper`` adds them (from ``runner.cms`` args and if ``--boilerplate`` was provided it adds ``aldryn_boilerplates``.
