### PR TITLE
Fix Attribute error when processing menu, minor code cleanup.

### DIFF
--- a/aldryn_faq/cms_toolbar.py
+++ b/aldryn_faq/cms_toolbar.py
@@ -77,7 +77,7 @@ class FaqToolbar(CMSToolbar):
     watch_models = (Category, )
     config = None
 
-    def __get_newsblog_config(self):
+    def __get_faq_config(self):
         try:
             __, config = get_app_instance(self.request)
             if not isinstance(config, FaqConfig):
@@ -91,7 +91,7 @@ class FaqToolbar(CMSToolbar):
 
     def get_on_delete_redirect_url(self, obj):
         if not self.config:
-            self.config = self.__get_newsblog_config()
+            self.config = self.__get_faq_config()
 
         if isinstance(obj, Category):
             url = reverse(
@@ -109,7 +109,7 @@ class FaqToolbar(CMSToolbar):
         return url
 
     def populate(self):
-        self.config = self.__get_newsblog_config()
+        self.config = self.__get_faq_config()
         user = getattr(self.request, 'user', None)
         try:
             view_name = self.request.resolver_match.view_name

--- a/aldryn_faq/menu.py
+++ b/aldryn_faq/menu.py
@@ -22,9 +22,9 @@ class FaqCategoryMenu(CMSAttachMenu):
     def get_nodes(self, request):
         nodes = []
         language = get_language_from_request(request, check_path=True)
+        # don't bother with categories that don't have appconfig.
         categories = Category.objects.active_translations(
-            language_code=language).distinct()
-
+            language_code=language).exclude(appconfig__isnull=True).distinct()
         if hasattr(self, 'instance') and self.instance:
             #
             # If self has a property `instance`
@@ -37,7 +37,6 @@ class FaqCategoryMenu(CMSAttachMenu):
             config = app.get_config(self.instance.application_namespace)
             if config:
                 categories = categories.filter(appconfig=config)
-
         for category in categories:
             try:
                 url = category.get_absolute_url(language=language)

--- a/aldryn_faq/models.py
+++ b/aldryn_faq/models.py
@@ -83,7 +83,8 @@ class Category(TranslatedAutoSlugifyMixin, TranslationHelperMixin,
                 'slug', default=None, language_code=language)[0] or ''
 
         kwargs = {}
-        permalink_type = self.appconfig.permalink_type
+        # since appconfig may be null/None, do not produce Attribute errors.
+        permalink_type = getattr(self.appconfig, 'permalink_type', '')
 
         if 'P' in permalink_type:
             kwargs.update({"category_pk": self.pk})


### PR DESCRIPTION
Error appears if category has no app config selected, and if you are checking on non existing language page.

Also clean up a 'newsblog' from method names.