### PR TITLE
Fix 500 issue for plugins if category has no namespace or it is not apphooked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,24 @@ env:
     - secure: gCi1UP9rgOnfvLT+UNiQkysnXUKvMi5ichNwPNxiXkLYlc66bJLIc/h8YI3V9vV4ICzyMJqEDHXV7T8NP0tsdxdNdEQNvStoaleLz7xsbjW7MZ2XxF13xncG6fksYr/5cjhBbiwg06HTn/VH+TD1FT1u9WUe+0/BJSx1JMnJQgs=
   matrix:
     - TOXENV=flake8
+    - TOXENV=py34-dj18-cms32
     - TOXENV=py34-dj18-cms31-fe
     - TOXENV=py34-dj17-cms31-fe
     - TOXENV=py34-dj17-cms30-fe
     - TOXENV=py34-dj16-cms31-fe
     - TOXENV=py34-dj16-cms30-fe
-    - TOXENV=py33-dj17-cms31-fe
-    - TOXENV=py33-dj17-cms30-fe
-    - TOXENV=py33-dj16-cms31-fe
-    - TOXENV=py33-dj16-cms30-fe
-    - TOXENV=py27-dj18-cms31-fe
-    - TOXENV=py27-dj17-cms31-fe
-    - TOXENV=py27-dj17-cms30-fe
+    - TOXENV=py33-dj17-cms31
+    - TOXENV=py33-dj17-cms30
+    - TOXENV=py33-dj16-cms31
+    - TOXENV=py33-dj16-cms30
+    - TOXENV=py27-dj18-cms32
+    - TOXENV=py27-dj18-cms31
+    - TOXENV=py27-dj17-cms32
+    - TOXENV=py27-dj17-cms31
+    - TOXENV=py27-dj17-cms30
+    - TOXENV=py27-dj16-cms32
     - TOXENV=py27-dj16-cms31-fe
-    - TOXENV=py27-dj16-cms30-fe
+    - TOXENV=py27-dj16-cms30
     - TOXENV=py26-dj16-cms31-fe
     - TOXENV=py26-dj16-cms30-fe
 

--- a/aldryn_faq/cms_wizards.py
+++ b/aldryn_faq/cms_wizards.py
@@ -15,7 +15,7 @@ from parler.forms import TranslatableModelForm
 
 from .cms_appconfig import FaqConfig
 from .models import Category, Question
-from .utils import namespace_is_apphooked
+from .utils import is_valid_namespace
 
 
 class ConfigCheckMixin(object):
@@ -32,7 +32,7 @@ class ConfigCheckMixin(object):
         configs = FaqConfig.objects.all()
         if not configs:
             return False
-        if not any([namespace_is_apphooked(config.namespace)
+        if not any([is_valid_namespace(config.namespace)
                     for config in configs]):
             return False
 
@@ -85,7 +85,7 @@ class CreateFaqCategoryForm(BaseFormMixin, TranslatableModelForm):
         # check if app config is apphooked
         app_configs = [app_config
                        for app_config in app_configs
-                       if namespace_is_apphooked(app_config.namespace)]
+                       if is_valid_namespace(app_config.namespace)]
         if len(app_configs) == 1:
             self.fields['appconfig'].widget = forms.HiddenInput()
             self.fields['appconfig'].initial = app_configs[0].pk

--- a/aldryn_faq/utils.py
+++ b/aldryn_faq/utils.py
@@ -49,7 +49,7 @@ def rename_tables_new_to_old(db, table_mapping=None):
     return rename_tables(db, table_mapping, reverse=True)
 
 
-def namespace_is_apphooked(namespace):
+def is_valid_namespace(namespace):
     """
     Check if provided namespace has an app-hooked page.
     Returns True or False.
@@ -59,3 +59,10 @@ def namespace_is_apphooked(namespace):
     except (NoReverseMatch, AttributeError):
         return False
     return True
+
+
+def is_valid_app_config(app_config):
+    """
+    Checks if provided app_config is valid. Tries to get namespace.
+    """
+    return getattr(app_config, 'namespace', None)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
-envlist = flake8, py{34,33,27,26}-dj{18}-cms{31}, py{34,33,27,26}-dj{17}-cms{31,30}, py{27,26}-dj16-cms{31,30}
+envlist =
+    flake8
+    py{34,33,27}-dj{18}-cms{32,31}
+    py{34,33,27,26}-dj{17}-cms{32,31,30}
+    py{27,26}-dj16-cms{32,31,30}
 skip_missing_interpreters = True
 
 [testenv]
@@ -20,6 +24,9 @@ deps =
     dj16: -rtest_requirements/django-1.6.txt
     dj17: -rtest_requirements/django-1.7.txt
     dj18: -rtest_requirements/django-1.8.txt
+    cms30: django-cms<3.1
+    cms31: django-cms<3.2
+    cms32: django-cms<3.3
     coveralls
 basepython =
     py26: python2.6


### PR DESCRIPTION
Error appears if category has an empty FAQ config and plugin that uses that category or question from that category was added to the page.

This ensures that such categories or questions from such categories are not displayed when rendering plugins.