### PR TITLE
Default FaqConfig: Django 1.6 and 1.7 migrations.

### DIFF
--- a/aldryn_faq/migrations/0001_initial.py
+++ b/aldryn_faq/migrations/0001_initial.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.conf import settings
-from django.db import models, migrations, transaction
-from django.db.models import get_model
-from django.db.utils import ProgrammingError, OperationalError
+from django.db import models, migrations
 import aldryn_translation_tools.models
 import app_data.fields
 import cms.models.fields

--- a/aldryn_faq/migrations/0001_initial.py
+++ b/aldryn_faq/migrations/0001_initial.py
@@ -1,12 +1,70 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.conf import settings
+from django.db import models, migrations, transaction
+from django.db.models import get_model
+from django.db.utils import ProgrammingError, OperationalError
 import aldryn_translation_tools.models
 import app_data.fields
 import cms.models.fields
 import sortedm2m.fields
 import djangocms_text_ckeditor.fields
+
+APP_PACKAGE = 'aldryn_faq'
+APP_CONFIG = 'FaqConfig'
+DEFAULT_NAMESPACE = 'aldryn_faq_default'
+DEFAULT_APP_TITLE = 'Default FAQ'
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+def get_config_count(model_class):
+    with transaction.atomic():
+        count = model_class.objects.count()
+    return count
+
+
+def create_default_config(apps, schema_editor):
+    FaqConfig = apps.get_model(APP_PACKAGE, APP_CONFIG)
+
+    # if we try to execute this migration after cms migrations were migrated
+    # to latest - we would get an exception because apps.get_model
+    # contains cms models in the last known state (which is the dependency
+    # migration state). If that is the case we need to import the real model.
+    try:
+        # to avoid the following error:
+        #   django.db.utils.InternalError: current transaction is aborted,
+        #   commands ignored until end of transaction block
+        # we need to cleanup or avoid that by making transaction atomic.
+        count = get_config_count(FaqConfig)
+    except (ProgrammingError, OperationalError):
+        model_path = '{0}.{1}'.format(APP_PACKAGE, APP_CONFIG)
+        FaqConfig = get_model(model_path)
+        count = get_config_count(FaqConfig)
+
+    if not count == 0:
+        return
+    # create only if there is no configs because user may already have
+    # existing and configured config.
+    app_config = FaqConfig(namespace=DEFAULT_NAMESPACE)
+    # usually generated in aldryn_apphooks_config.models.AppHookConfig
+    # but in migrations we don't have real class with correct parents.
+    app_config.type = '{0}.cms_appconfig.{1}'.format(APP_PACKAGE, APP_CONFIG)
+    # placeholders
+    # cms checks if instance.pk is set, and if it isn't cms creates a new
+    # placeholder but it does that with real models, and fields on instance
+    # are faked models. To prevent that we need to manually set instance pk.
+    app_config.pk = 1
+    app_config.save()
+
+    # translations
+    app_config_translation = app_config.translations.create()
+    app_config_translation.language_code = settings.LANGUAGES[0][0]
+    app_config_translation.app_title = DEFAULT_APP_TITLE
+    app_config_translation.save()
 
 
 class Migration(migrations.Migration):
@@ -197,4 +255,6 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(verbose_name='appconfig', blank=True, to='aldryn_faq.FaqConfig', null=True),
             preserve_default=True,
         ),
+        # create default FaqConfig
+        migrations.RunPython(create_default_config, noop)
     ]

--- a/aldryn_faq/migrations/0001_initial.py
+++ b/aldryn_faq/migrations/0001_initial.py
@@ -11,61 +11,6 @@ import cms.models.fields
 import sortedm2m.fields
 import djangocms_text_ckeditor.fields
 
-APP_PACKAGE = 'aldryn_faq'
-APP_CONFIG = 'FaqConfig'
-DEFAULT_NAMESPACE = 'aldryn_faq_default'
-DEFAULT_APP_TITLE = 'Default FAQ'
-
-
-def noop(apps, schema_editor):
-    pass
-
-
-def get_config_count(model_class):
-    with transaction.atomic():
-        count = model_class.objects.count()
-    return count
-
-
-def create_default_config(apps, schema_editor):
-    FaqConfig = apps.get_model(APP_PACKAGE, APP_CONFIG)
-
-    # if we try to execute this migration after cms migrations were migrated
-    # to latest - we would get an exception because apps.get_model
-    # contains cms models in the last known state (which is the dependency
-    # migration state). If that is the case we need to import the real model.
-    try:
-        # to avoid the following error:
-        #   django.db.utils.InternalError: current transaction is aborted,
-        #   commands ignored until end of transaction block
-        # we need to cleanup or avoid that by making transaction atomic.
-        count = get_config_count(FaqConfig)
-    except (ProgrammingError, OperationalError):
-        model_path = '{0}.{1}'.format(APP_PACKAGE, APP_CONFIG)
-        FaqConfig = get_model(model_path)
-        count = get_config_count(FaqConfig)
-
-    if not count == 0:
-        return
-    # create only if there is no configs because user may already have
-    # existing and configured config.
-    app_config = FaqConfig(namespace=DEFAULT_NAMESPACE)
-    # usually generated in aldryn_apphooks_config.models.AppHookConfig
-    # but in migrations we don't have real class with correct parents.
-    app_config.type = '{0}.cms_appconfig.{1}'.format(APP_PACKAGE, APP_CONFIG)
-    # placeholders
-    # cms checks if instance.pk is set, and if it isn't cms creates a new
-    # placeholder but it does that with real models, and fields on instance
-    # are faked models. To prevent that we need to manually set instance pk.
-    app_config.pk = 1
-    app_config.save()
-
-    # translations
-    app_config_translation = app_config.translations.create()
-    app_config_translation.language_code = settings.LANGUAGES[0][0]
-    app_config_translation.app_title = DEFAULT_APP_TITLE
-    app_config_translation.save()
-
 
 class Migration(migrations.Migration):
 
@@ -255,6 +200,4 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(verbose_name='appconfig', blank=True, to='aldryn_faq.FaqConfig', null=True),
             preserve_default=True,
         ),
-        # create default FaqConfig
-        migrations.RunPython(create_default_config, noop)
     ]

--- a/aldryn_faq/migrations/0004_auto_20150626_1205.py
+++ b/aldryn_faq/migrations/0004_auto_20150626_1205.py
@@ -1,75 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations, transaction
-from django.db.models import get_model
-from django.db.utils import ProgrammingError, OperationalError
+from django.db import models, migrations
 import cms.models.fields
-
-APP_PACKAGE = 'aldryn_faq'
-APP_CONFIG = 'FaqConfig'
-
-
-def noop(apps, schema_editor):
-    pass
-
-
-def get_configs(model_class):
-    with transaction.atomic():
-        app_configs = list(model_class.objects.all())
-    return app_configs
-
-
-def create_placeholders(app_config):
-    """
-    Creates placeholder instances for each Placeholder field on provided
-    app_config.
-    """
-    import cms.models.fields
-    from cms.models import Placeholder
-
-    for field in app_config._meta.fields:
-        if not field.__class__ == cms.models.fields.PlaceholderField:
-            # skip other fields.
-            continue
-        placeholder_name = field.name
-        placeholder_id_name = '{0}_id'.format(placeholder_name)
-        placeholder_id = getattr(app_config, placeholder_id_name, None)
-        if placeholder_id is not None:
-            # do not process if it has a reference to placeholder field.
-            continue
-        # since there is no placeholder - create it, we cannot use
-        # get_or_create because it can get placeholder from other config
-        new_placeholder = Placeholder.objects.create(
-            slot=placeholder_name)
-        setattr(app_config, placeholder_id_name, new_placeholder.pk)
-    # after we process all placeholder fields - save config,
-    # so that django can pick up them.
-    app_config.save()
-
-
-def create_placeholders_for_app_configs(apps, schema_editor):
-    FaqConfig = apps.get_model(APP_PACKAGE, APP_CONFIG)
-    # if we try to execute this migration after cms migrations were migrated
-    # to latest - we would get an exception because apps.get_model
-    # contains cms models in the last known state (which is the dependency
-    # migration state). If that is the case we need to import the real model.
-    try:
-        # to avoid the following error:
-        #   django.db.utils.InternalError: current transaction is aborted,
-        #   commands ignored until end of transaction block
-        # we need to cleanup or avoid that by making transaction atomic.
-        app_configs = get_configs(FaqConfig)
-    except (ProgrammingError, OperationalError):
-        model_path = '{0}.{1}'.format(APP_PACKAGE, APP_CONFIG)
-        FaqConfig = get_model(model_path)
-        app_configs = get_configs(FaqConfig)
-
-    if not app_configs:
-        return
-
-    for app_config in app_configs:
-        create_placeholders(app_config)
 
 
 class Migration(migrations.Migration):
@@ -110,6 +43,4 @@ class Migration(migrations.Migration):
             field=cms.models.fields.PlaceholderField(related_name='aldryn_faq_sidebar_top', slotname='faq_sidebar_top', editable=False, to='cms.Placeholder', null=True),
             preserve_default=True,
         ),
-        # create default FaqConfig placeholders
-        migrations.RunPython(create_placeholders_for_app_configs, noop)
     ]

--- a/aldryn_faq/migrations/0004_auto_20150626_1205.py
+++ b/aldryn_faq/migrations/0004_auto_20150626_1205.py
@@ -1,8 +1,75 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import models, migrations, transaction
+from django.db.models import get_model
+from django.db.utils import ProgrammingError, OperationalError
 import cms.models.fields
+
+APP_PACKAGE = 'aldryn_faq'
+APP_CONFIG = 'FaqConfig'
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+def get_configs(model_class):
+    with transaction.atomic():
+        app_configs = list(model_class.objects.all())
+    return app_configs
+
+
+def create_placeholders(app_config):
+    """
+    Creates placeholder instances for each Placeholder field on provided
+    app_config.
+    """
+    import cms.models.fields
+    from cms.models import Placeholder
+
+    for field in app_config._meta.fields:
+        if not field.__class__ == cms.models.fields.PlaceholderField:
+            # skip other fields.
+            continue
+        placeholder_name = field.name
+        placeholder_id_name = '{0}_id'.format(placeholder_name)
+        placeholder_id = getattr(app_config, placeholder_id_name, None)
+        if placeholder_id is not None:
+            # do not process if it has a reference to placeholder field.
+            continue
+        # since there is no placeholder - create it, we cannot use
+        # get_or_create because it can get placeholder from other config
+        new_placeholder = Placeholder.objects.create(
+            slot=placeholder_name)
+        setattr(app_config, placeholder_id_name, new_placeholder.pk)
+    # after we process all placeholder fields - save config,
+    # so that django can pick up them.
+    app_config.save()
+
+
+def create_placeholders_for_app_configs(apps, schema_editor):
+    FaqConfig = apps.get_model(APP_PACKAGE, APP_CONFIG)
+    # if we try to execute this migration after cms migrations were migrated
+    # to latest - we would get an exception because apps.get_model
+    # contains cms models in the last known state (which is the dependency
+    # migration state). If that is the case we need to import the real model.
+    try:
+        # to avoid the following error:
+        #   django.db.utils.InternalError: current transaction is aborted,
+        #   commands ignored until end of transaction block
+        # we need to cleanup or avoid that by making transaction atomic.
+        app_configs = get_configs(FaqConfig)
+    except (ProgrammingError, OperationalError):
+        model_path = '{0}.{1}'.format(APP_PACKAGE, APP_CONFIG)
+        FaqConfig = get_model(model_path)
+        app_configs = get_configs(FaqConfig)
+
+    if not app_configs:
+        return
+
+    for app_config in app_configs:
+        create_placeholders(app_config)
 
 
 class Migration(migrations.Migration):
@@ -43,4 +110,6 @@ class Migration(migrations.Migration):
             field=cms.models.fields.PlaceholderField(related_name='aldryn_faq_sidebar_top', slotname='faq_sidebar_top', editable=False, to='cms.Placeholder', null=True),
             preserve_default=True,
         ),
+        # create default FaqConfig placeholders
+        migrations.RunPython(create_placeholders_for_app_configs, noop)
     ]

--- a/aldryn_faq/migrations/0010_auto_20160109_2144.py
+++ b/aldryn_faq/migrations/0010_auto_20160109_2144.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='faqconfig',
             name='app_data',
-            field=app_data.fields.AppDataField(default=b'{}', editable=False),
+            field=app_data.fields.AppDataField(default='{}', editable=False),
         ),
     ]

--- a/aldryn_faq/migrations/0011_create_default_faq_config.py
+++ b/aldryn_faq/migrations/0011_create_default_faq_config.py
@@ -22,7 +22,7 @@ def get_config_count(model_class):
     return count
 
 
-def create_placeholders(app_config):
+def create_placeholders(app_config, save=True):
     """
     Creates placeholder instances for each Placeholder field on provided
     app_config.
@@ -43,11 +43,12 @@ def create_placeholders(app_config):
         # since there is no placeholder - create it, we cannot use
         # get_or_create because it can get placeholder from other config
         new_placeholder = Placeholder.objects.create(
-            slot=placeholder_name)
+            slot=field.slotname)
         setattr(app_config, placeholder_id_name, new_placeholder.pk)
     # after we process all placeholder fields - save config,
     # so that django can pick up them.
-    # app_config.save()
+    if save:
+        app_config.save()
 
 
 def create_default_config(apps, schema_editor):
@@ -69,6 +70,8 @@ def create_default_config(apps, schema_editor):
         count = get_config_count(FaqConfig)
 
     if not count == 0:
+        for cfg in FaqConfig.objects.all():
+            create_placeholders(cfg)
         return
     # create only if there is no configs because user may already have
     # existing and configured config.
@@ -82,7 +85,7 @@ def create_default_config(apps, schema_editor):
     # are faked models. To prevent that we need to manually set instance pk.
     app_config.pk = 1
     # placeholders
-    create_placeholders(app_config)
+    create_placeholders(app_config, save=False)
     app_config.save()
 
     # translations
@@ -90,9 +93,6 @@ def create_default_config(apps, schema_editor):
     app_config_translation.language_code = settings.LANGUAGES[0][0]
     app_config_translation.app_title = DEFAULT_APP_TITLE
     app_config_translation.save()
-
-
-
 
 
 class Migration(migrations.Migration):

--- a/aldryn_faq/migrations/0011_create_default_faq_config.py
+++ b/aldryn_faq/migrations/0011_create_default_faq_config.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import models, migrations, transaction
+from django.db.models import get_model
+from django.db.utils import ProgrammingError, OperationalError
+
+APP_PACKAGE = 'aldryn_faq'
+APP_CONFIG = 'FaqConfig'
+DEFAULT_NAMESPACE = 'aldryn_faq_default'
+DEFAULT_APP_TITLE = 'Default FAQ'
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+def get_config_count(model_class):
+    with transaction.atomic():
+        count = model_class.objects.count()
+    return count
+
+
+def create_placeholders(app_config):
+    """
+    Creates placeholder instances for each Placeholder field on provided
+    app_config.
+    """
+    import cms.models.fields
+    from cms.models import Placeholder
+
+    for field in app_config._meta.fields:
+        if not field.__class__ == cms.models.fields.PlaceholderField:
+            # skip other fields.
+            continue
+        placeholder_name = field.name
+        placeholder_id_name = '{0}_id'.format(placeholder_name)
+        placeholder_id = getattr(app_config, placeholder_id_name, None)
+        if placeholder_id is not None:
+            # do not process if it has a reference to placeholder field.
+            continue
+        # since there is no placeholder - create it, we cannot use
+        # get_or_create because it can get placeholder from other config
+        new_placeholder = Placeholder.objects.create(
+            slot=placeholder_name)
+        setattr(app_config, placeholder_id_name, new_placeholder.pk)
+    # after we process all placeholder fields - save config,
+    # so that django can pick up them.
+    # app_config.save()
+
+
+def create_default_config(apps, schema_editor):
+    FaqConfig = apps.get_model(APP_PACKAGE, APP_CONFIG)
+
+    # if we try to execute this migration after cms migrations were migrated
+    # to latest - we would get an exception because apps.get_model
+    # contains cms models in the last known state (which is the dependency
+    # migration state). If that is the case we need to import the real model.
+    try:
+        # to avoid the following error:
+        #   django.db.utils.InternalError: current transaction is aborted,
+        #   commands ignored until end of transaction block
+        # we need to cleanup or avoid that by making transaction atomic.
+        count = get_config_count(FaqConfig)
+    except (ProgrammingError, OperationalError):
+        model_path = '{0}.{1}'.format(APP_PACKAGE, APP_CONFIG)
+        FaqConfig = get_model(model_path)
+        count = get_config_count(FaqConfig)
+
+    if not count == 0:
+        return
+    # create only if there is no configs because user may already have
+    # existing and configured config.
+    app_config = FaqConfig(namespace=DEFAULT_NAMESPACE)
+    # usually generated in aldryn_apphooks_config.models.AppHookConfig
+    # but in migrations we don't have real class with correct parents.
+    app_config.type = '{0}.cms_appconfig.{1}'.format(APP_PACKAGE, APP_CONFIG)
+    # placeholders
+    # cms checks if instance.pk is set, and if it isn't cms creates a new
+    # placeholder but it does that with real models, and fields on instance
+    # are faked models. To prevent that we need to manually set instance pk.
+    app_config.pk = 1
+    # placeholders
+    create_placeholders(app_config)
+    app_config.save()
+
+    # translations
+    app_config_translation = app_config.translations.create()
+    app_config_translation.language_code = settings.LANGUAGES[0][0]
+    app_config_translation.app_title = DEFAULT_APP_TITLE
+    app_config_translation.save()
+
+
+
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0003_auto_20140926_2347'),
+        ('aldryn_faq', '0010_auto_20160109_2144')
+    ]
+
+    operations = [
+        migrations.RunPython(create_default_config, noop)
+    ]

--- a/aldryn_faq/south_migrations/0024_create_default_faq_config.py
+++ b/aldryn_faq/south_migrations/0024_create_default_faq_config.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+
+from django.conf import settings
+from django.db import models, connection, transaction
+
+
+def create_placeholders(app_config, orm):
+    """
+    Creates placeholder instances for each Placeholder field on provided
+    app_config.
+    """
+    from cms.models import Placeholder
+
+    for field in app_config._meta.fields:
+        if field.__class__ != models.fields.related.ForeignKey:
+            # skip not FK fields
+            continue
+
+        if not (field.rel.to == Placeholder or
+                field.rel.to == orm['cms.Placeholder']):
+            # skip other fields.
+            continue
+
+        placeholder_name = field.name
+        placeholder_id_name = '{0}_id'.format(placeholder_name)
+        placeholder_id = getattr(app_config, placeholder_id_name, None)
+        if placeholder_id is not None:
+            # do not process if it has a reference to placeholder field.
+            continue
+        # since there is no placeholder - create it, we cannot use
+        # get_or_create because it can get placeholder from other config
+        new_placeholder = Placeholder.objects.create(
+            slot=placeholder_name)
+        setattr(app_config, placeholder_id_name, new_placeholder.pk)
+    # after we process all placeholder fields - save config,
+    # so that django can pick up them.
+    app_config.save()
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName".
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+        if connection.vendor == 'sqlite':
+            transaction.set_autocommit(True)
+        FaqConfig = orm.FaqConfig
+        Category = orm.Category
+        app_config_count = FaqConfig.objects.count()
+        app_config, created = FaqConfig.objects.get_or_create(
+            namespace='aldryn_faq_default')
+
+        if created:
+            app_config_translation = app_config.translations.create()
+            app_config_translation.language_code = settings.LANGUAGES[0][0]
+            app_config_translation.app_title = 'Default FAQ'
+            app_config_translation.save()
+
+        # set app config for categoris only if there were
+        # no other existing app configs.
+        if app_config_count == 0:
+            for entry in Category.objects.filter(appconfig__isnull=True):
+                entry.appconfig = app_config
+                entry.save()
+
+        # create all missing placeholders
+        for cfg in FaqConfig.objects.all():
+            create_placeholders(cfg, orm)
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+        pass
+
+    models = {
+        u'aldryn_faq.category': {
+            'Meta': {'object_name': 'Category'},
+            'appconfig': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_faq.FaqConfig']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'aldryn_faq.categorylistplugin': {
+            'Meta': {'object_name': 'CategoryListPlugin', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'aldryn_faq.categorytranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'CategoryTranslation', 'db_table': "u'aldryn_faq_category_translation'"},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_faq.Category']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'aldryn_faq.faqconfig': {
+            'Meta': {'object_name': 'FaqConfig'},
+            'app_data': ('app_data.fields.AppDataField', [], {'default': "'{}'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'namespace': ('django.db.models.fields.CharField', [], {'default': 'None', 'unique': 'True', 'max_length': '100'}),
+            'non_permalink_handling': ('django.db.models.fields.SmallIntegerField', [], {'default': '302'}),
+            'permalink_type': ('django.db.models.fields.CharField', [], {'default': "u'Ss'", 'max_length': '2'}),
+            'placeholder_faq_content': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_faq_content'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_faq_list_bottom': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_faq_list_bottom'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_faq_list_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_faq_list_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_faq_sidebar_bottom': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_faq_sidebar_bottom'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_faq_sidebar_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_faq_sidebar_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'aldryn_faq.faqconfigtranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'FaqConfigTranslation', 'db_table': "u'aldryn_faq_faqconfig_translation'"},
+            'app_title': ('django.db.models.fields.CharField', [], {'max_length': '234'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_faq.FaqConfig']"})
+        },
+        u'aldryn_faq.latestquestionsplugin': {
+            'Meta': {'object_name': 'LatestQuestionsPlugin', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'questions': ('django.db.models.fields.IntegerField', [], {'default': '5'})
+        },
+        u'aldryn_faq.mostreadquestionsplugin': {
+            'Meta': {'object_name': 'MostReadQuestionsPlugin', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'questions': ('django.db.models.fields.IntegerField', [], {'default': '5'})
+        },
+        u'aldryn_faq.question': {
+            'Meta': {'ordering': "(u'order',)", 'object_name': 'Question'},
+            'answer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'faq_questions'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'questions'", 'to': u"orm['aldryn_faq.Category']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_top': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'number_of_visits': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1', 'db_index': 'True'})
+        },
+        u'aldryn_faq.questionlistplugin': {
+            'Meta': {'object_name': 'QuestionListPlugin', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'questions': ('sortedm2m.fields.SortedManyToManyField', [], {'to': u"orm['aldryn_faq.Question']", 'symmetrical': 'False'})
+        },
+        u'aldryn_faq.questiontranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'QuestionTranslation', 'db_table': "u'aldryn_faq_question_translation'"},
+            'answer_text': ('djangocms_text_ckeditor.fields.HTMLField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_faq.Question']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'aldryn_faq.selectedcategory': {
+            'Meta': {'ordering': "[u'position']", 'object_name': 'SelectedCategory'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_faq.Category']"}),
+            'cms_plugin': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'selected_categories'", 'to': u"orm['aldryn_faq.CategoryListPlugin']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_faq.topquestionsplugin': {
+            'Meta': {'object_name': 'TopQuestionsPlugin', '_ormbases': ['cms.CMSPlugin']},
+            u'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['cms.CMSPlugin']", 'unique': 'True', 'primary_key': 'True'}),
+            'questions': ('django.db.models.fields.IntegerField', [], {'default': '5'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['aldryn_faq']
+    symmetrical = True

--- a/aldryn_faq/south_migrations/0024_create_default_faq_config.py
+++ b/aldryn_faq/south_migrations/0024_create_default_faq_config.py
@@ -33,7 +33,7 @@ def create_placeholders(app_config, orm):
         # since there is no placeholder - create it, we cannot use
         # get_or_create because it can get placeholder from other config
         new_placeholder = Placeholder.objects.create(
-            slot=placeholder_name)
+            slot=field.slotname)
         setattr(app_config, placeholder_id_name, new_placeholder.pk)
     # after we process all placeholder fields - save config,
     # so that django can pick up them.

--- a/aldryn_faq/south_migrations/0024_create_default_faq_config.py
+++ b/aldryn_faq/south_migrations/0024_create_default_faq_config.py
@@ -25,6 +25,9 @@ def create_placeholders(app_config, orm):
             continue
 
         placeholder_name = field.name
+        # south doesn't keeps the field.slotname, so we have to pick it
+        # up from field.name
+        slot_name = placeholder_name.replace('placeholder_', '')
         placeholder_id_name = '{0}_id'.format(placeholder_name)
         placeholder_id = getattr(app_config, placeholder_id_name, None)
         if placeholder_id is not None:
@@ -33,7 +36,7 @@ def create_placeholders(app_config, orm):
         # since there is no placeholder - create it, we cannot use
         # get_or_create because it can get placeholder from other config
         new_placeholder = Placeholder.objects.create(
-            slot=field.slotname)
+            slot=slot_name)
         setattr(app_config, placeholder_id_name, new_placeholder.pk)
     # after we process all placeholder fields - save config,
     # so that django can pick up them.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+import sys
 from setuptools import setup, find_packages
 from aldryn_faq import __version__
+
+py26 = (2, 7, 0) > sys.version_info >= (2, 6, 0)
 
 REQUIREMENTS = [
     'aldryn-apphooks-config>=0.2.4',
@@ -15,12 +18,21 @@ REQUIREMENTS = [
     'django-parler>=1.4,<1.7',
     'django-reversion>=1.8.2,<1.11',
     'django-sortedm2m',
-    'django-taggit',
 
     # THIS IS HERE TO SUPPORT EXISTING MIGRATIONS AND CAN BE REMOVED ONLY ONCE
     # WE NO LONGER SUPPORT SOUTH MIGRATIONS.
     'django-admin-sortable',
 ]
+
+# use appropriate 3rd party packages versions
+if py26:
+    REQUIREMENTS += [
+        'django-taggit<0.18.0',
+    ]
+else:
+    REQUIREMENTS += [
+        'django-taggit',
+    ]
 
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 CLASSIFIERS = [

--- a/test_requirements/django-1.8.in
+++ b/test_requirements/django-1.8.in
@@ -1,5 +1,6 @@
 django>=1.8.0,<1.9
-aldryn-reversion>=1.9.3,<1.11
+# fixme: replace to >=1.9.3,<1.11 after cms issue would be fixed
+django-reversion>=1.9.3,<1.10
 djangocms-helper
 aldryn-apphook-reload
 tox

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -1,3 +1,4 @@
 django>=1.8.0,<1.9
-django-reversion>=1.9.3,<1.11
+# fixme: replace to >=1.9.3,<1.11 after cms issue would be fixed
+django-reversion>=1.9.3,<1.10
 -r base.txt

--- a/test_settings.py
+++ b/test_settings.py
@@ -98,7 +98,7 @@ HELPER_SETTINGS = {
             },
             {
                 'code': 'fr',
-                'name': u'Française',
+                'name': 'French',
                 'fallbacks': ['en', ]
             },
         ],


### PR DESCRIPTION
* Create default FaqConfig (Django 1.6 (south) migrations and Django style
* Create placeholders for FaqConfigs (if for some reasons they were not created or at least for the default one)
* Pins ``django-taggit`` version for Python 2.6
* Temporary decreases ``django-reversion`` version in test requirements to fix test runs. Should be adjusted after CMS 3.2.1 release.
