### PR TITLE
Fix tests for 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,20 +20,20 @@ env:
     #                different Python ENVs if possible.
     # NOTE: FE-TESTS ARE DISABLED UNTIL THEY ARE FIXED FOR CMS 3.2
     - TOXENV=flake8
-    - TOXENV=py34-dj18-cms32
+    - TOXENV=py34-dj18-cms32-fe
     - TOXENV=py34-dj18-cms31
     - TOXENV=py27-dj18-cms32
     - TOXENV=py27-dj18-cms31
     - TOXENV=py34-dj17-cms32
     - TOXENV=py34-dj17-cms31
     - TOXENV=py34-dj17-cms30
-    - TOXENV=py27-dj17-cms32
+    - TOXENV=py27-dj17-cms32-fe
     - TOXENV=py27-dj17-cms31
     - TOXENV=py27-dj17-cms30
     - TOXENV=py27-dj16-cms32
     - TOXENV=py27-dj16-cms31
     - TOXENV=py27-dj16-cms30
-    - TOXENV=py26-dj16-cms32
+    - TOXENV=py26-dj16-cms32-fe
     - TOXENV=py26-dj16-cms31
     - TOXENV=py26-dj16-cms30
 

--- a/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
+++ b/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
@@ -4,38 +4,39 @@
  */
 
 'use strict';
-/* global by, element, expect */
+/* global browser, by, element, expect */
 
 // #############################################################################
 // INTEGRATION TEST PAGE OBJECT
 
-var cmsProtractorHelper = require('cms-protractor-helper');
-
-var faqPage = {
+var page = {
     site: 'http://127.0.0.1:8000/en/',
 
     // log in
     editModeLink: element(by.css('.inner a[href="/?edit"]')),
-    usernameInput: element(by.id('id_cms-username')),
-    passwordInput: element(by.id('id_cms-password')),
-    loginButton: element(by.css('.cms_form-login input[type="submit"]')),
-    userMenus: element.all(by.css('.cms_toolbar-item-navigation > li > a')),
-    testLink: element(by.css('.selected a')),
+    usernameInput: element(by.id('id_username')),
+    passwordInput: element(by.id('id_password')),
+    loginButton: element(by.css('input[type="submit"]')),
+    userMenus: element.all(by.css('.cms-toolbar-item-navigation > li > a')),
 
     // adding new page
+    modalCloseButton: element(by.css('.cms-modal-close')),
     userMenuDropdown: element(by.css(
-        '.cms_toolbar-item-navigation-hover')),
+        '.cms-toolbar-item-navigation-hover')),
     administrationOptions: element.all(by.css(
-        '.cms_toolbar-item-navigation a[href="/en/admin/"]')),
-    sideMenuIframe: element(by.css('.cms_sideframe-frame iframe')),
+        '.cms-toolbar-item-navigation a[href="/en/admin/"]')),
+    sideMenuIframe: element(by.css('.cms-sideframe-frame iframe')),
     pagesLink: element(by.css('.model-page > th > a')),
     addPageLink: element(by.css('.sitemap-noentry .addlink')),
     titleInput: element(by.id('id_title')),
     slugErrorNotification: element(by.css('.errors.slug')),
     saveButton: element(by.css('.submit-row [name="_save"]')),
-    editPageLink: element(by.css('.col1 [href*="preview/"]')),
+    editPageLink: element(by.css('.col-preview [href*="preview/"]')),
+    testLink: element(by.cssContainingText('a', 'Test')),
+    sideFrameClose: element(by.css('.cms-sideframe-close')),
 
     // adding new apphook config
+    breadcrumbs: element(by.css('.breadcrumbs')),
     breadcrumbsLinks: element.all(by.css('.breadcrumbs a')),
     faqConfigsLink: element(by.css('.model-faqconfig > th > a')),
     editConfigsLink: element(by.css('.row1 th > a')),
@@ -53,22 +54,24 @@ var faqPage = {
 
     // adding new question
     addQuestionButton: element(by.css('.model-question .addlink')),
+    editQuestionButton: element(by.css('.model-question .changelink')),
     categorySelect: element(by.id('id_category')),
     categoryOption: element(by.css('#id_category > option:nth-child(2)')),
     ckeIframe: element(by.css('#cke_1_contents iframe')),
     ckeEditableBlock: element(by.css('.cke_editable')),
     saveAndContinueButton: element(by.css('.submit-row [name="_continue"]')),
+    editQuestionLinksTable: element(by.css('.results')),
     editQuestionLinks: element.all(by.css(
         '.results th > [href*="/aldryn_faq/question/"]')),
 
     // adding faq block to the page
     aldrynFAQBlock: element(by.css('.aldryn-faq-categories')),
     advancedSettingsOption: element(by.css(
-        '.cms_toolbar-item-navigation [href*="advanced-settings"]')),
-    modalIframe: element(by.css('.cms_modal-frame iframe')),
+        '.cms-toolbar-item-navigation [href*="advanced-settings"]')),
+    modalIframe: element(by.css('.cms-modal-frame iframe')),
     applicationSelect: element(by.id('application_urls')),
     faqOption: element(by.css('option[value="FaqApp"]')),
-    saveModalButton: element(by.css('.cms_modal-buttons .cms_btn-action')),
+    saveModalButton: element(by.css('.cms-modal-buttons .cms-btn-action')),
     categoryLink: element(by.css('.aldryn-faq-categories a')),
     questionLink: element(by.css('.aldryn-faq .list-group a')),
     questionTitle: element(by.css('.aldryn-faq-detail h2 > div')),
@@ -83,26 +86,34 @@ var faqPage = {
         credentials = credentials ||
             { username: 'admin', password: 'admin' };
 
-        faqPage.usernameInput.clear();
+        page.usernameInput.clear();
 
         // fill in email field
-        return faqPage.usernameInput.sendKeys(credentials.username)
-            .then(function () {
-            faqPage.passwordInput.clear();
+        page.usernameInput.sendKeys(
+            credentials.username).then(function () {
+            page.passwordInput.clear();
 
             // fill in password field
-            return faqPage.passwordInput.sendKeys(credentials.password);
+            return page.passwordInput.sendKeys(
+                credentials.password);
         }).then(function () {
-            faqPage.loginButton.click();
+            return page.loginButton.click();
+        }).then(function () {
+            // this is required for django1.6, because it doesn't redirect
+            // correctly from admin
+            browser.get(page.site);
 
             // wait for user menu to appear
-            cmsProtractorHelper.waitFor(faqPage.userMenus.first());
+            browser.wait(browser.isElementPresent(
+                page.userMenus.first()),
+                page.mainElementsWaitTime);
 
             // validate user menu
-            expect(faqPage.userMenus.first().isDisplayed()).toBeTruthy();
+            expect(page.userMenus.first().isDisplayed())
+                .toBeTruthy();
         });
     }
 
 };
 
-module.exports = faqPage;
+module.exports = page;

--- a/aldryn_faq/tests/frontend/integration/specs/spec.faq.crud.js
+++ b/aldryn_faq/tests/frontend/integration/specs/spec.faq.crud.js
@@ -20,17 +20,13 @@ describe('Aldryn FAQ tests: ', function () {
         browser.get(faqPage.site);
 
         // check if the page already exists
-        return faqPage.testLink.isPresent().then(function (present) {
+        faqPage.testLink.isPresent().then(function (present) {
             if (present === true) {
                 // go to the main page
                 browser.get(faqPage.site + '?edit');
-            } else {
-                // click edit mode link
-                faqPage.editModeLink.click();
+                browser.sleep(1000);
+                cmsProtractorHelper.waitForDisplayed(faqPage.usernameInput);
             }
-
-            // wait for username input to appear
-            cmsProtractorHelper.waitFor(faqPage.usernameInput);
 
             // login to the site
             faqPage.cmsLogin();
@@ -38,6 +34,17 @@ describe('Aldryn FAQ tests: ', function () {
     });
 
     it('creates a new test page', function () {
+        // close the wizard if necessary
+        faqPage.modalCloseButton.isDisplayed().then(function (displayed) {
+            if (displayed) {
+                faqPage.modalCloseButton.click();
+            }
+        });
+
+        cmsProtractorHelper.waitForDisplayed(faqPage.userMenus.first());
+        // have to wait till animation finished
+        browser.sleep(300);
+
         // click the example.com link in the top menu
         return faqPage.userMenus.first().click().then(function () {
             // wait for top menu dropdown options to appear
@@ -50,7 +57,7 @@ describe('Aldryn FAQ tests: ', function () {
 
             // switch to sidebar menu iframe
             browser.switchTo().frame(browser.findElement(
-                By.css('.cms_sideframe-frame iframe')));
+                By.css('.cms-sideframe-frame iframe')));
 
             cmsProtractorHelper.waitFor(faqPage.pagesLink);
 
@@ -108,13 +115,20 @@ describe('Aldryn FAQ tests: ', function () {
 
                 // switch to sidebar menu iframe
                 return browser.switchTo().frame(browser.findElement(By.css(
-                    '.cms_sideframe-frame iframe')));
+                    '.cms-sideframe-frame iframe')));
             }
         }).then(function () {
-            cmsProtractorHelper.waitFor(faqPage.breadcrumbsLinks.first());
-
             // click the Home link in breadcrumbs
-            faqPage.breadcrumbsLinks.first().click();
+            browser.sleep(1000);
+
+            faqPage.breadcrumbs.isPresent().then(function (present) {
+                if (present) {
+                    // click the Home link in breadcrumbs
+                    cmsProtractorHelper.waitFor(faqPage.breadcrumbsLinks.first());
+                    faqPage.breadcrumbsLinks.first().click();
+                }
+            });
+
 
             cmsProtractorHelper.waitFor(faqPage.faqConfigsLink);
 
@@ -225,7 +239,7 @@ describe('Aldryn FAQ tests: ', function () {
 
             // switch to sidebar menu iframe
             browser.switchTo().frame(browser.findElement(By.css(
-                '.cms_sideframe-frame iframe')));
+                '.cms-sideframe-frame iframe')));
 
             cmsProtractorHelper.waitFor(faqPage.saveAndContinueButton);
 
@@ -244,8 +258,16 @@ describe('Aldryn FAQ tests: ', function () {
     });
 
     it('adds a new faq block on the page', function () {
+        // go to the main page
+        browser.get(faqPage.site);
+
         // switch to default page content
         browser.switchTo().defaultContent();
+
+        cmsProtractorHelper.waitFor(faqPage.testLink);
+
+        // wait till animation finishes
+        browser.sleep(300);
 
         // add faq to the page only if it was not added before
         return faqPage.aldrynFAQBlock.isPresent().then(function (present) {
@@ -262,7 +284,7 @@ describe('Aldryn FAQ tests: ', function () {
 
                     // switch to modal iframe
                     browser.switchTo().frame(browser.findElement(By.css(
-                        '.cms_modal-frame iframe')));
+                        '.cms-modal-frame iframe')));
 
                     // wait for Application select to appear
                     cmsProtractorHelper.waitFor(faqPage.applicationSelect);
@@ -282,8 +304,21 @@ describe('Aldryn FAQ tests: ', function () {
                 });
             }
         }).then(function () {
+            // refresh the page to see changes
+            browser.refresh();
+
             // wait for aldryn-faq block to appear
             cmsProtractorHelper.waitFor(faqPage.aldrynFAQBlock);
+
+            // wait till animation of sideframe opening finishes
+            browser.sleep(300);
+
+            // close sideframe (it covers the link)
+            cmsProtractorHelper.waitFor(faqPage.sideFrameClose);
+            faqPage.sideFrameClose.click();
+
+            // wait till animation finishes
+            browser.sleep(300);
 
             faqPage.categoryLink.click();
 
@@ -300,18 +335,34 @@ describe('Aldryn FAQ tests: ', function () {
     });
 
     it('deletes question', function () {
-        // wait for modal iframe to appear
-        cmsProtractorHelper.waitFor(faqPage.sideMenuIframe);
+        cmsProtractorHelper.waitForDisplayed(faqPage.userMenus.first());
+        // have to wait till animation finished
+        browser.sleep(300);
+        // click the example.com link in the top menu
+        faqPage.userMenus.first().click().then(function () {
+            // wait for top menu dropdown options to appear
+            cmsProtractorHelper.waitForDisplayed(faqPage.userMenuDropdown);
+
+            return faqPage.administrationOptions.first().click();
+        }).then(function () {
+            // wait for modal iframe to appear
+            cmsProtractorHelper.waitFor(faqPage.sideMenuIframe);
+        });
+
 
         // switch to sidebar menu iframe
         browser.switchTo()
-            .frame(browser.findElement(By.css('.cms_sideframe-frame iframe')));
+            .frame(browser.findElement(By.css('.cms-sideframe-frame iframe')));
 
-        // wait for edit question link to appear
-        cmsProtractorHelper.waitFor(faqPage.editQuestionLinks.first());
-
-        // validate edit question links texts to delete proper question
-        return faqPage.editQuestionLinks.first().getText().then(function (text) {
+        cmsProtractorHelper.waitFor(faqPage.editQuestionButton);
+        browser.sleep(100);
+        faqPage.editQuestionButton.click().then(function () {
+            // wait for edit job opening link to appear
+            return cmsProtractorHelper.waitFor(faqPage.editQuestionLinksTable);
+        }).then(function () {
+            // validate edit faq entry links texts to delete proper faq entry
+            return faqPage.editQuestionLinks.first().getText();
+        }).then(function (text) {
             if (text === questionName) {
                 return faqPage.editQuestionLinks.first().click();
             } else {

--- a/aldryn_faq/tests/frontend/integration/specs/spec.faq.crud.js
+++ b/aldryn_faq/tests/frontend/integration/specs/spec.faq.crud.js
@@ -129,7 +129,6 @@ describe('Aldryn FAQ tests: ', function () {
                 }
             });
 
-
             cmsProtractorHelper.waitFor(faqPage.faqConfigsLink);
 
             faqPage.faqConfigsLink.click();

--- a/aldryn_faq/tests/frontend/protractor.conf.js
+++ b/aldryn_faq/tests/frontend/protractor.conf.js
@@ -20,8 +20,7 @@ var config = {
 
     // Capabilities to be passed to the webdriver instance
     capabilities: {
-        'browserName': 'phantomjs',
-        'phantomjs.binary.path': require('phantomjs').path
+        'browserName': 'chrome'
     },
 
     onPrepare: function () {
@@ -36,7 +35,8 @@ var config = {
 
     jasmineNodeOpts: {
         showColors: true,
-        defaultTimeoutInterval: 240000
+        defaultTimeoutInterval: 240000,
+        realtimeFailure: true
     }
 
 };

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from distutils.version import LooseVersion
+from cms import __version__ as cms_string_version
+
+cms_version = LooseVersion(cms_string_version)
+
+
 HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
@@ -51,7 +57,7 @@ HELPER_SETTINGS = {
     ],
     # This set of MW classes should work for Django 1.6 and 1.7.
     'MIDDLEWARE_CLASSES': [
-        'aldryn_apphook_reload.middleware.ApphookReloadMiddleware',
+        'cms.middleware.utils.ApphookReloadMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -104,6 +110,15 @@ HELPER_SETTINGS = {
         'taggit': 'taggit.south_migrations',
     }
 }
+
+
+# If using CMS 3.2+, use the CMS middleware for ApphookReloading, otherwise,
+# use aldryn_apphook_reload's.
+if cms_version < LooseVersion('3.2.0'):
+    HELPER_SETTINGS['MIDDLEWARE_CLASSES'].remove(
+        'cms.middleware.utils.ApphookReloadMiddleware')
+    HELPER_SETTINGS['MIDDLEWARE_CLASSES'].insert(
+        0, 'aldryn_apphook_reload.middleware.ApphookReloadMiddleware')
 
 
 def run():

--- a/test_settings.py
+++ b/test_settings.py
@@ -33,6 +33,7 @@ HELPER_SETTINGS = {
         ('de', 'German'),
         ('fr', 'French'),
     ),
+    'CMS_PERMISSION': True,
     'INSTALLED_APPS': [
         'adminsortable2',
         'aldryn_apphook_reload',


### PR DESCRIPTION
- changes tests so they work with 3.2
    - sideframe is now covering most of the view so it has to be opened/closed
    - admin behaviour changed slightly
    - selectors changed
    - added additional safety waits
- change the default local runner from phantomjs to chrome because literally nothing works in phantom (and http://www.protractortest.org/#/browser-support)
- add CMS_PERMISSION setting, because apparently there is a bug in the 3.2 that hides the Pages menu item if it's not set
- change the way apphook reload is loaded for 3.2 vs 3.1