### PR TITLE
Django 1.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ env:
     #                different Python ENVs if possible.
     # NOTE: FE-TESTS ARE DISABLED UNTIL THEY ARE FIXED FOR CMS 3.2
     - TOXENV=flake8
+    - TOXENV=py34-dj19-cms32
+    - TOXENV=py27-dj19-cms32
     - TOXENV=py34-dj18-cms32-fe
     - TOXENV=py34-dj18-cms31
     - TOXENV=py27-dj18-cms32
@@ -30,10 +32,9 @@ env:
     - TOXENV=py27-dj17-cms32-fe
     - TOXENV=py27-dj17-cms31
     - TOXENV=py27-dj17-cms30
-    - TOXENV=py27-dj16-cms32
+    - TOXENV=py27-dj16-cms32-fe
     - TOXENV=py27-dj16-cms31
     - TOXENV=py27-dj16-cms30
-    - TOXENV=py26-dj16-cms32-fe
     - TOXENV=py26-dj16-cms31
     - TOXENV=py26-dj16-cms30
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+x.x.xx (xxxx-xx-xx)
+-------------------
+
+* Add Django 1.9 support.
+* Clean up test environments.
+* Add default FaqConfig migrations.
+
 1.0.11 (2016-01-12)
 -------------------
 

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/pager.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/pager.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load url from future %}
 
 <div class="aldryn-faq-pager">
     <ul class="pager">

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/question_list.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/question_list.html
@@ -1,5 +1,4 @@
 {% load i18n cms_tags %}
-{% load url from future %}
 
 {% regroup object_list|dictsort:"category_id" by category as qgroups %}
 

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/ungrouped_question_list.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/includes/ungrouped_question_list.html
@@ -1,5 +1,4 @@
 {% load cms_tags i18n %}
-{% load url from future %}
 
 <div class="list-group">
     {% for question in object_list %}

--- a/aldryn_faq/boilerplates/legacy/templates/aldryn_faq/includes/question_groups.html
+++ b/aldryn_faq/boilerplates/legacy/templates/aldryn_faq/includes/question_groups.html
@@ -1,5 +1,4 @@
 {% load i18n placeholder_tags %}
-{% load url from future %}
 
 {% regroup object_list|dictsort:"category_id" by category as qgroups %}
 {% for qgroup in qgroups %}

--- a/aldryn_faq/boilerplates/legacy/templates/aldryn_faq/includes/question_list.html
+++ b/aldryn_faq/boilerplates/legacy/templates/aldryn_faq/includes/question_list.html
@@ -1,5 +1,4 @@
 {% load i18n placeholder_tags sekizai_tags %}
-{% load url from future %}
 {% load cms_tags %}
 
 {% regroup object_list|dictsort:"category_id" by category as qgroups %}

--- a/aldryn_faq/boilerplates/legacy/templates/aldryn_faq/question_detail.html
+++ b/aldryn_faq/boilerplates/legacy/templates/aldryn_faq/question_detail.html
@@ -1,6 +1,5 @@
 {% extends "aldryn_faq/base.html" %}
 {% load i18n cms_tags %}
-{% load url from future %}
 
 {% block content_faq %}
 <div class="faq-detail">

--- a/aldryn_faq/migrations/0011_create_default_faq_config.py
+++ b/aldryn_faq/migrations/0011_create_default_faq_config.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.db import models, migrations, transaction
-from django.db.models import get_model
+from django.apps import apps as django_apps
 from django.db.utils import ProgrammingError, OperationalError
 
 APP_PACKAGE = 'aldryn_faq'
@@ -66,7 +66,7 @@ def create_default_config(apps, schema_editor):
         count = get_config_count(FaqConfig)
     except (ProgrammingError, OperationalError):
         model_path = '{0}.{1}'.format(APP_PACKAGE, APP_CONFIG)
-        FaqConfig = get_model(model_path)
+        FaqConfig = django_apps.get_model(model_path)
         count = get_config_count(FaqConfig)
 
     if not count == 0:

--- a/aldryn_faq/tests/test_base.py
+++ b/aldryn_faq/tests/test_base.py
@@ -17,8 +17,6 @@ from cms.utils import get_cms_setting
 from cms.utils.i18n import get_language_list
 from djangocms_helper.utils import create_user
 
-from aldryn_search.helpers import get_request
-
 from ..models import Category, Question, FaqConfig
 
 User = get_user_model()
@@ -32,10 +30,13 @@ class TestUtilityMixin(object):
     def assertEqualItems(self, a, b):
         try:
             # In Python3, this method has been renamed (poorly)
-            return self.assertCountEqual(a, b)
-        except:
+            assertCountEqual = self.assertCountEqual
+        except AttributeError:
             # In 2.6, assertItemsEqual() doesn't sort first
-            return self.assertItemsEqual(sorted(a), sorted(b))
+            def assertCountEqual(a, b):
+                return self.assertItemsEqual(sorted(a), sorted(b))
+
+        return assertCountEqual(a, b)
 
 
 class AldrynFaqTestMixin(TestUtilityMixin, object):
@@ -182,7 +183,6 @@ class CMSRequestBasedTest(TestUtilityMixin, TransactionTestCase):
             apphook_namespace=self.app_config.namespace
         )
         self.placeholder = self.page.placeholders.all()[0]
-        self.request = get_request('en')
 
         for page in [self.root_page, self.page]:
             for language, _ in settings.LANGUAGES[1:]:

--- a/aldryn_faq/tests/test_reversions.py
+++ b/aldryn_faq/tests/test_reversions.py
@@ -4,7 +4,10 @@ from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
 
-import reversion
+try:
+    from reversion.revisions import create_revision, get_for_object
+except ImportError:
+    from reversion import create_revision, get_for_object
 
 from django.db import transaction
 
@@ -46,7 +49,7 @@ class CommonAldrynReversionsAdminMixinTestCaseMixin(object):
         for field in self.text_fields_to_change:
             setattr(object_instance, field, self.rand_str(prefix='dummy_'))
         with transaction.atomic():
-            with reversion.create_revision():
+            with create_revision():
                 object_instance.save()
 
     def get_object_instance(self):
@@ -59,7 +62,7 @@ class CommonAldrynReversionsAdminMixinTestCaseMixin(object):
 
     def test_category_recovery_accessible(self):
         object_instance = self.get_object_instance()
-        version = reversion.get_for_object(object_instance)[0]
+        version = get_for_object(object_instance)[0]
         object_pk = object_instance.pk
         self.assertEqual(self.model_class.objects.filter(
             pk=object_pk).count(), 1)

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@ py26 = (2, 7, 0) > sys.version_info >= (2, 6, 0)
 
 REQUIREMENTS = [
     'aldryn-apphooks-config>=0.2.4',
-    'aldryn-boilerplates>=0.6.0',
-    'aldryn-reversion>=1.0.0',
+    'aldryn-boilerplates>=0.7.4,<0.8',
+    'aldryn-reversion>=1.0.4,<1.1',
     'aldryn-search',
     'aldryn-translation-tools>=0.2.1',
-    'django>=1.6,<1.9',
+    'django>=1.6,<1.9.999',
     'django-admin-sortable2>=0.5.2',
     'django-cms>=3.0.12,<3.3',
     'djangocms-text-ckeditor',
@@ -41,6 +41,8 @@ CLASSIFIERS = [
     'Framework :: Django',
     'Framework :: Django :: 1.6',
     'Framework :: Django :: 1.7',
+    'Framework :: Django :: 1.8',
+    'Framework :: Django :: 1.9',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -1,16 +1,12 @@
 aldryn-boilerplates>=0.6.0
-aldryn-reversion>=1.0.4
 aldryn-translation-tools>=0.1.0
-aldryn-apphook-reload
 coverage==3.7.1
 django-classy-tags
-django-mptt<0.7
 django-parler>=1.4
 django-sekizai>=0.8.2
 django-sortedm2m
-django-taggit
 djangocms-admin-style
-djangocms-helper>=0.9.1
+djangocms-helper>=0.9.4
 djangocms-text-ckeditor
 docopt
 flake8
@@ -29,9 +25,9 @@ django-admin-sortable
 
 # The following are for aldryn-search
 lxml
-django-appconf==0.6 # rq.filter: <0.6
+django-appconf
 aldryn-common
 django-haystack>=2.0.0
 django-spurl
 django-standard-form
-aldryn-search
+aldryn-search>=0.2.11,<0.3

--- a/test_requirements/django-1.6.txt
+++ b/test_requirements/django-1.6.txt
@@ -1,3 +1,5 @@
+aldryn-reversion>=1.0.4
+django-taggit<0.18.0
 django>=1.6,<1.7
 django-reversion>=1.8.2,<1.8.3
 South

--- a/test_requirements/django-1.7.txt
+++ b/test_requirements/django-1.7.txt
@@ -1,3 +1,6 @@
+aldryn-reversion>=1.0.4
+django-taggit
 django>=1.7.4,<1.8
 django-reversion>=1.8.2,<1.9
+
 -r base.txt

--- a/test_requirements/django-1.8.in
+++ b/test_requirements/django-1.8.in
@@ -1,5 +1,5 @@
 django>=1.8.0,<1.9
-# fixme: replace to >=1.9.3,<1.11 after cms issue would be fixed
+aldryn-reversion>=1.0.4
 django-reversion>=1.9.3,<1.10
 djangocms-helper
 aldryn-apphook-reload

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -1,4 +1,6 @@
+aldryn-reversion>=1.0.4
+django-taggit
 django>=1.8.0,<1.9
-# fixme: replace to >=1.9.3,<1.11 after cms issue would be fixed
 django-reversion>=1.9.3,<1.10
+
 -r base.txt

--- a/test_requirements/django-1.9.in
+++ b/test_requirements/django-1.9.in
@@ -1,0 +1,5 @@
+django>=1.9.0,<1.10
+django-reversion>=1.10,<1.11
+djangocms-helper
+aldryn-apphook-reload
+tox

--- a/test_requirements/django-1.9.txt
+++ b/test_requirements/django-1.9.txt
@@ -1,0 +1,6 @@
+aldryn-reversion>=1.0.8
+django-taggit
+django>=1.9.0,<1.10
+django-reversion>=1.10,<1.11
+
+-r base.txt

--- a/test_settings.py
+++ b/test_settings.py
@@ -42,7 +42,6 @@ HELPER_SETTINGS = {
     'CMS_PERMISSION': True,
     'INSTALLED_APPS': [
         'adminsortable2',
-        'aldryn_apphook_reload',
         'aldryn_reversion',
         'aldryn_translation_tools',
         'djangocms_text_ckeditor',
@@ -55,7 +54,6 @@ HELPER_SETTINGS = {
         # required for testing the migrations.
         'adminsortable',
     ],
-    # This set of MW classes should work for Django 1.6 and 1.7.
     'MIDDLEWARE_CLASSES': [
         'cms.middleware.utils.ApphookReloadMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
@@ -111,10 +109,10 @@ HELPER_SETTINGS = {
     }
 }
 
-
 # If using CMS 3.2+, use the CMS middleware for ApphookReloading, otherwise,
 # use aldryn_apphook_reload's.
 if cms_version < LooseVersion('3.2.0'):
+    HELPER_SETTINGS['INSTALLED_APPS'].insert(0, 'aldryn_apphook_reload'),
     HELPER_SETTINGS['MIDDLEWARE_CLASSES'].remove(
         'cms.middleware.utils.ApphookReloadMiddleware')
     HELPER_SETTINGS['MIDDLEWARE_CLASSES'].insert(

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
     flake8
-    py{34,33,27}-dj{18}-cms{32,31}
-    py{34,33,27}-dj{17}-cms{32,31,30}
-    py{33,27,26}-dj{16}-cms{32,31,30}
-
+    py{34,27}-dj19-cms32
+    py{34,33,27}-dj18-cms{32,31}
+    py{34,33,27}-dj17-cms{32,31,30}
+    py{33,27,26}-dj16-cms{32,31,30}
 skip_missing_interpreters = True
 
 [testenv]
@@ -25,8 +25,11 @@ deps =
     dj16: -rtest_requirements/django-1.6.txt
     dj17: -rtest_requirements/django-1.7.txt
     dj18: -rtest_requirements/django-1.8.txt
+    dj19: -rtest_requirements/django-1.9.txt
     cms30: django-cms<3.1
+    cms30: aldryn-apphook-reload
     cms31: django-cms<3.2
+    cms31: aldryn-apphook-reload
     cms32: django-cms<3.3
     coveralls
 basepython =


### PR DESCRIPTION
Add support for Django 1.9

TODO:
The tests are currently failing because of the change in aldryn-search master branch, which adds [CMSToolbar](https://github.com/aldryn/aldryn-search/compare/4ed4d4f...master#diff-d403482dc4982f4388d9400dcd974c1fR90) to request. So we have two simple workarounds: remove that toolbar from request or even remove self.request in [aldryn-faq base test class](https://github.com/aldryn/aldryn-faq/blob/master/aldryn_faq/tests/test_base.py#L185).

Use releases for:

 * ~~aldryn-search~~
 * aldryn-reversion
