### PR TITLE
Use CMS_TEMPLATE instead of hardcoding the template name.

### DIFF
--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/base.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/base.html
@@ -1,3 +1,3 @@
-{% extends "base.html" %}
+{% extends CMS_TEMPLATE %}
 
 {% block content %}{% endblock %}


### PR DESCRIPTION
Template name may be different, so use proper cms variable instead of hardcode.
