### PR TITLE
Issue/faq category reverse

### DIFF
--- a/aldryn_faq/tests/test_base.py
+++ b/aldryn_faq/tests/test_base.py
@@ -89,6 +89,29 @@ class AldrynFaqTestMixin(TestUtilityMixin, object):
         }
     }
 
+    settings_en = {
+        'LANGUAGES': (
+            ('en', 'English'),
+        ),
+        'LANGUAGE': 'en',
+        'PARLER_LANGUAGES': {
+            1: (
+                {'code': 'en'},
+            ),
+            'default': {
+                'hide_untranslated': False,
+            },
+        },
+        'CMS_LANGUAGES': {
+            1: (
+                {'code': 'en', 'name': 'English'},
+            ),
+            'default': {
+                'hide_untranslated': False,
+            },
+        },
+    }
+
     @staticmethod
     def reload(obj, language=None):
         """Simple convenience method for re-fetching an object from the ORM,

--- a/aldryn_faq/tests/test_base.py
+++ b/aldryn_faq/tests/test_base.py
@@ -43,8 +43,8 @@ class AldrynFaqTestMixin(TestUtilityMixin, object):
     """Sets up basic Category and Question objects for testing."""
     data = {
         "category1": {
-            "en": {"name": "Example", "slug": "example", },
-            "de": {"name": "Beispiel", "slug": "beispiel", }
+            "en": {"name": "Example1", "slug": "example", },
+            "de": {"name": "Beispiel1", "slug": "beispiel", }
         },
         "category2": {
             # This should *not* have a EN translation

--- a/aldryn_faq/tests/test_search_indexes.py
+++ b/aldryn_faq/tests/test_search_indexes.py
@@ -59,7 +59,7 @@ class TestCategoryIndex(AldrynFaqTest):
         idx_obj = CategoryIndex()
         category1 = self.reload(self.category1, "en")
         search_data = idx_obj.get_search_data(category1, "en", None)
-        self.assertEqual(search_data, "Example")
+        self.assertEqual(search_data, category1.name)
 
         # This isn't working, but I think it proves that the search index
         # doesn't actually work translatedly.

--- a/aldryn_faq/views.py
+++ b/aldryn_faq/views.py
@@ -273,9 +273,9 @@ class FaqByCategoryView(CanonicalUrlMixin, FaqCategoryMixin, ListView):
         return super(FaqByCategoryView, self).get_category()
 
     def get_context_data(self, **kwargs):
-        kwargs['category_list'] = self.get_category_queryset(
-            ).active_translations(self.current_language).filter(
-                appconfig=self.config)
+        kwargs['category_list'] = (
+            self.get_category_queryset().active_translations(
+                self.current_language).filter(appconfig=self.config))
         kwargs['active_category'] = self.get_category()
         return super(FaqByCategoryView, self).get_context_data(**kwargs)
 

--- a/aldryn_faq/views.py
+++ b/aldryn_faq/views.py
@@ -273,7 +273,9 @@ class FaqByCategoryView(CanonicalUrlMixin, FaqCategoryMixin, ListView):
         return super(FaqByCategoryView, self).get_category()
 
     def get_context_data(self, **kwargs):
-        kwargs['category_list'] = self.get_category_queryset()
+        kwargs['category_list'] = self.get_category_queryset(
+            ).active_translations(self.current_language).filter(
+                appconfig=self.config)
         kwargs['active_category'] = self.get_category()
         return super(FaqByCategoryView, self).get_context_data(**kwargs)
 
@@ -313,5 +315,5 @@ class FaqByCategoryListView(FaqCategoryMixin, ListView):
 
     def get_queryset(self):
         return self.model.objects.language(
-            language_code=self.current_language).filter(
-                appconfig=self.config)
+            language_code=self.current_language).active_translations(
+                self.current_language).filter(appconfig=self.config)


### PR DESCRIPTION
Fix Issue with faq category url reversing for disabled language:

 * Tests: use unique category names to allow lookup in response
 * Show only translated categories to prevent reverse() errors
 * Test category list view with different (edge case) settings