### PR TITLE
Simplify templates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,22 @@
 CHANGELOG
 =========
 
+
+1.1.0 UNRELEASED)
+-------------------
+
+* Add stripped default django templates to `/aldryn_newsblog/templates`
+* Remove unused render_placeholder configs
+* Add static_placeholders where necessary
+* Simplify templates
+
+
 1.0.13 (2016-02-25)
 -------------------
 
 * Fixes error if tags were filled with non-ascii characters.
 * Added an optional description field to category.
+
 
 1.0.12 (2016-02-12)
 -------------------
@@ -14,16 +25,19 @@ CHANGELOG
 * Clean up test environments.
 * Add default FaqConfig migrations.
 
+
 1.0.11 (2016-01-12)
 -------------------
 
 * Adjust requirements for django-reversion to allow 1.10
+
 
 1.0.10 (2016-01-12)
 -------------------
 
 * Improves support for current versions of django-reversion
 * Adds FE tests against DMS 3.2
+
 
 1.0.9 (2016-01-09)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ CHANGELOG
 1.1.0 UNRELEASED)
 -------------------
 
-* Add stripped default django templates to `/aldryn_newsblog/templates`
+* Add stripped default django templates to `/aldryn_faq/templates`
 * Remove unused render_placeholder configs
 * Add static_placeholders where necessary
 * Simplify templates

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include app.yaml
 include README.rst
 recursive-include aldryn_faq/boilerplates *
+recursive-include aldryn_faq/templates *
 recursive-exclude * *.pyc

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/base.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/base.html
@@ -1,3 +1,3 @@
-{% extends "base.html" %}
+{% extends CMS_TEMPLATE %}
 
 {% block content %}{% endblock %}

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/fullwidth.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/fullwidth.html
@@ -6,7 +6,6 @@
         <div class="row">
             <div class="col-md-16 col-md-push-4">
                 <div class="aldryn aldryn-faq">
-                    {% block faq_title %}{% endblock %}
                     {% block faq_content %}{% endblock %}
                 </div>
             </div>

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/plugins/category_list.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/plugins/category_list.html
@@ -1,15 +1,12 @@
-{% load i18n cms_tags %}
+{% load i18n %}
 
 <div class="aldryn aldryn-faq aldryn-faq-categories">
     <div class="list-group">
         {% for category in categories %}
             <a href="{{ category.get_absolute_url }}" class="list-group-item
                 {% if category.pk == active_category.pk %} active{% endif %}">
+                {{ category }}
                 <span class="badge">{{ category.count }}</span>
-                <h5 class="list-group-item-heading">{{ category }}</h5>
-                {% if category.description %}
-                    {% render_model category "description" %}
-                {% endif %}
             </a>
         {% empty %}
             <p class="list-group-item">{% trans "No entry found." %}</p>

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/question_detail.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/question_detail.html
@@ -1,13 +1,13 @@
 {% extends "aldryn_faq/fullwidth.html" %}
 {% load i18n cms_tags %}
 
+{% block breadcrumb %}{% endblock %}
+
 {% block faq_content %}
     <article class="aldryn aldryn-faq aldryn-faq-detail">
-        {% block faq_detail_categories %}
-            <a href="{{ category_url }}" class="label label-primary">
-                {% render_model object "category" "category" %}
-            </a>
-        {% endblock faq_detail_categories %}
+        <a href="{{ category_url }}" class="label label-primary">
+            {% render_model object "category" "category" %}
+        </a>
 
         {% if object.tags.all %}
             <div class="tags pull-right">
@@ -17,27 +17,20 @@
             </div>
         {% endif %}
 
-        {% block faq_detail_title %}
-            <h2>{% render_model object "title" %}</h2>
-        {% endblock faq_detail_title %}
+        <h2>{% render_model object "title" %}</h2>
 
-        {% block faq_detail_lead %}
-            {% if question.answer_text %}
-                <div class="lead">
-                    {% render_model object "answer_text" "answer_text" "" safe %}
-                </div>
-            {% endif %}
-        {% endblock faq_detail_lead %}
-
-        {% block faq_detail_content %}
-            <div class="content">
-                {% render_placeholder object.answer 800 %}
+        {% if question.answer_text %}
+            <div class="lead">
+                {% render_model object "answer_text" "answer_text" "" safe %}
             </div>
-        {% endblock faq_detail_content %}
+        {% endif %}
+
+        <div class="content">
+            {% render_placeholder object.answer 800 %}
+        </div>
     </article>
 {% endblock %}
 
 {% block faq_footer %}
     {% include "aldryn_faq/includes/pager.html" with title=_("Back to Category") slug=category_url %}
-    {% static_placeholder "faq_detail_bottom" %}
 {% endblock %}

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/question_list.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/question_list.html
@@ -2,14 +2,10 @@
 {% load i18n cms_tags %}
 
 {% block faq_content %}
-    {% render_placeholder view.config.placeholder_faq_list_top %}
     {% with list="true" %}
         {% include "aldryn_faq/includes/question_list.html" %}
     {% endwith %}
-{% endblock %}
 
-{% block faq_footer %}
     {% url 'aldryn_faq:faq-category-list' as category_list_url %}
     {% include "aldryn_faq/includes/pager.html" with title=_("Back to Overview") slug=category_list_url %}
-    {% render_placeholder view.config.placeholder_faq_list_bottom %}
 {% endblock %}

--- a/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/two_column.html
+++ b/aldryn_faq/boilerplates/bootstrap3/templates/aldryn_faq/two_column.html
@@ -6,18 +6,14 @@
         <div class="row">
             <div class="col-md-17 col-md-push-7">
                 <div class="aldryn aldryn-faq">
-                    {% block faq_title %}{% endblock %}
                     {% block faq_content %}
-                        {% render_placeholder view.config.placeholder_faq_content %}
+                        {% static_placeholder "faq_article_list" %}
                     {% endblock %}
-                    {% block faq_footer %}{% endblock %}
                 </div>
             </div>
             <div class="col-md-7 col-md-pull-17 aldryn-faq aldryn-faq-sidebar">
                 {% block faq_sidebar %}
-                    {% render_placeholder view.config.placeholder_faq_sidebar_top %}
                     {% include "aldryn_faq/plugins/category_list.html" with categories=category_list %}
-                    {% render_placeholder view.config.placeholder_faq_sidebar_bottom %}
                 {% endblock %}
             </div>
         </div>

--- a/aldryn_faq/templates/aldryn_faq/base.html
+++ b/aldryn_faq/templates/aldryn_faq/base.html
@@ -1,0 +1,7 @@
+{% extends CMS_TEMPLATE %}
+
+{% block content %}
+    {% block faq_content %}
+        {# question_list.html and question_detail.html extend this template #}
+    {% endblock %}
+{% endblock content %}

--- a/aldryn_faq/templates/aldryn_faq/includes/question_list.html
+++ b/aldryn_faq/templates/aldryn_faq/includes/question_list.html
@@ -1,0 +1,40 @@
+{% load i18n cms_tags %}
+
+{% regroup object_list|dictsort:"category_id" by category as qgroups %}
+{% for qgroup in qgroups %}
+    {% if list %}
+        <h2>{{ qgroup.grouper }}</h2>
+    {% endif %}
+
+    <ul>
+        {% for question in qgroup.list %}
+            <li>
+                <a href="{{ question.get_absolute_url }}">
+                    <h3>
+                        {% render_model question "title" %}
+                        {% if not list %}
+                            {{ qgroup.grouper }}
+                        {% endif %}
+                        {% for tag in question.tags.all %}
+                            <span>{{ tag }}{% if not forloop.last %}, {% endif %}</span>
+                        {% endfor %}
+                    </h3>
+                    {% if view.config.app_data.config.show_description %}
+                        {% render_model question "answer_text" %}
+                    {% endif %}
+                </a>
+            </li>
+        {% empty %}
+            <li>{% trans "No entry found." %}</li>
+        {% endfor %}
+    </ul>
+{% empty %}
+    {% if list %}
+        <h3>{{ qgroup.grouper|default:_("Category") }}</h3>
+    {% endif %}
+    <p>{% trans "No entry found." %}</p>
+{% endfor %}
+
+{% if list and title %}
+    <p><a href="{{ object.category.get_absolute_url }}">{% trans "Back to Category" %}</a></p>
+{% endif %}

--- a/aldryn_faq/templates/aldryn_faq/includes/ungrouped_question_list.html
+++ b/aldryn_faq/templates/aldryn_faq/includes/ungrouped_question_list.html
@@ -1,0 +1,21 @@
+{% load cms_tags i18n %}
+
+<ul>
+    {% for question in object_list %}
+        <li>
+            <a href="{{ question.get_absolute_url }}">
+                <h3>
+                    {% render_model question "title" %}
+                    {% for tag in question.tags.all %}
+                        <span>{{ tag }}</span>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
+                </h3>
+                {% if view.config.app_data.config.show_description %}
+                    {% render_model question "answer_text" %}
+                {% endif %}
+            </a>
+        </li>
+    {% empty %}
+        <li>{% trans "No entry found." %}</li>
+    {% endfor %}
+</ul>

--- a/aldryn_faq/templates/aldryn_faq/landing.html
+++ b/aldryn_faq/templates/aldryn_faq/landing.html
@@ -3,4 +3,5 @@
 
 {% block faq_content %}
     {% static_placeholder "faq_content" %}
+    {% include "aldryn_faq/plugins/category_list.html" with categories=category_list %}
 {% endblock %}

--- a/aldryn_faq/templates/aldryn_faq/landing.html
+++ b/aldryn_faq/templates/aldryn_faq/landing.html
@@ -1,4 +1,4 @@
-{% extends CMS_TEMPLATE %}
+{% extends "aldryn_faq/base.html" %}
 {% load cms_tags %}
 
 {% block faq_content %}

--- a/aldryn_faq/templates/aldryn_faq/landing.html
+++ b/aldryn_faq/templates/aldryn_faq/landing.html
@@ -1,0 +1,6 @@
+{% extends CMS_TEMPLATE %}
+{% load cms_tags %}
+
+{% block faq_content %}
+    {% static_placeholder "faq_content" %}
+{% endblock %}

--- a/aldryn_faq/templates/aldryn_faq/plugins/category_list.html
+++ b/aldryn_faq/templates/aldryn_faq/plugins/category_list.html
@@ -1,0 +1,19 @@
+{% load i18n cms_tags %}
+
+<ul>
+    {% for category in categories %}
+        <li>
+            <a href="{{ category.get_absolute_url }}">
+                <h3>
+                    {{ category }}
+                    <span>{{ category.count }}</span>
+                </h3>
+                {% if category.description %}
+                    {% render_model category "description" %}
+                {% endif %}
+            </a>
+        </li>
+    {% empty %}
+        <li>{% trans "No entry found." %}</li>
+    {% endfor %}
+</ul>

--- a/aldryn_faq/templates/aldryn_faq/plugins/latest_questions.html
+++ b/aldryn_faq/templates/aldryn_faq/plugins/latest_questions.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+
+{% include "aldryn_faq/includes/ungrouped_question_list.html" with object_list=instance.get_questions %}

--- a/aldryn_faq/templates/aldryn_faq/plugins/most_read_questions.html
+++ b/aldryn_faq/templates/aldryn_faq/plugins/most_read_questions.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+
+{% include "aldryn_faq/includes/ungrouped_question_list.html" with object_list=instance.get_questions %}

--- a/aldryn_faq/templates/aldryn_faq/plugins/question_list.html
+++ b/aldryn_faq/templates/aldryn_faq/plugins/question_list.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+
+{% include "aldryn_faq/includes/ungrouped_question_list.html" with object_list=instance.get_questions %}

--- a/aldryn_faq/templates/aldryn_faq/plugins/top_questions.html
+++ b/aldryn_faq/templates/aldryn_faq/plugins/top_questions.html
@@ -1,0 +1,3 @@
+{% load i18n %}
+
+{% include "aldryn_faq/includes/ungrouped_question_list.html" with object_list=instance.get_questions %}

--- a/aldryn_faq/templates/aldryn_faq/question_detail.html
+++ b/aldryn_faq/templates/aldryn_faq/question_detail.html
@@ -1,0 +1,30 @@
+{% extends "aldryn_faq/base.html" %}
+{% load i18n cms_tags %}
+
+{% block faq_content %}
+    <article>
+        <h2>{% render_model object "title" %}</h2>
+
+        <p>
+            <a href="{{ category_url }}">
+                {% render_model object "category" "category" %}
+            </a>
+        </p>
+
+        {% if object.tags.all %}
+            <p>
+                {% for tag in object.tags.all %}
+                    {{ tag }}{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </p>
+        {% endif %}
+
+        {% if question.answer_text %}
+            {% render_model object "answer_text" "answer_text" "" safe %}
+        {% endif %}
+
+        {% render_placeholder object.answer 800 %}
+
+        <p><a href="{{ category_url }}">{% trans "Back to Category" %}</a></p>
+    </article>
+{% endblock %}

--- a/aldryn_faq/templates/aldryn_faq/question_list.html
+++ b/aldryn_faq/templates/aldryn_faq/question_list.html
@@ -6,5 +6,7 @@
         {% include "aldryn_faq/includes/question_list.html" %}
     {% endwith %}
 
+    {% include "aldryn_faq/plugins/category_list.html" with categories=category_list %}
+
     <p><a href="{% url "aldryn_faq:faq-category-list" %}">{% trans "Back to Overview" %}</a></p>
 {% endblock %}

--- a/aldryn_faq/templates/aldryn_faq/question_list.html
+++ b/aldryn_faq/templates/aldryn_faq/question_list.html
@@ -1,0 +1,10 @@
+{% extends "aldryn_faq/base.html" %}
+{% load i18n %}
+
+{% block faq_content %}
+    {% with list="true" %}
+        {% include "aldryn_faq/includes/question_list.html" %}
+    {% endwith %}
+
+    <p><a href="{% url "aldryn_faq:faq-category-list" %}">{% trans "Back to Overview" %}</a></p>
+{% endblock %}

--- a/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
+++ b/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
@@ -65,16 +65,16 @@ var page = {
         '.results th > [href*="/aldryn_faq/question/"]')),
 
     // adding faq block to the page
-    aldrynFAQBlock: element(by.css('.aldryn-faq-categories')),
+    aldrynFAQBlock: element(by.css('ul.nav ~ ul')),
     advancedSettingsOption: element(by.css(
         '.cms-toolbar-item-navigation [href*="advanced-settings"]')),
     modalIframe: element(by.css('.cms-modal-frame iframe')),
     applicationSelect: element(by.id('application_urls')),
     faqOption: element(by.css('option[value="FaqApp"]')),
     saveModalButton: element(by.css('.cms-modal-buttons .cms-btn-action')),
-    categoryLink: element(by.css('.aldryn-faq-categories a')),
-    questionLink: element(by.css('.aldryn-faq .list-group a')),
-    questionTitle: element(by.css('.aldryn-faq-detail h2 > div')),
+    categoryLink: element(by.css('a[href*="/test-category/"]')),
+    questionLink: element(by.css('a[href*="/test-category/test-question"]')),
+    questionTitle: element(by.css('article h2')),
 
     // deleting question
     deleteButton: element(by.css('.deletelink-box a')),

--- a/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
+++ b/aldryn_faq/tests/frontend/integration/pages/page.faq.crud.js
@@ -27,11 +27,11 @@ var page = {
         '.cms-toolbar-item-navigation a[href="/en/admin/"]')),
     sideMenuIframe: element(by.css('.cms-sideframe-frame iframe')),
     pagesLink: element(by.css('.model-page > th > a')),
-    addPageLink: element(by.css('.sitemap-noentry .addlink')),
+    addPageLink: element(by.css('.object-tools .addlink')),
     titleInput: element(by.id('id_title')),
     slugErrorNotification: element(by.css('.errors.slug')),
     saveButton: element(by.css('.submit-row [name="_save"]')),
-    editPageLink: element(by.css('.col-preview [href*="preview/"]')),
+    editPageLink: element(by.css('.cms-tree-item-preview [href*="preview/"]')),
     testLink: element(by.cssContainingText('a', 'Test')),
     sideFrameClose: element(by.css('.cms-sideframe-close')),
 

--- a/aldryn_faq/tests/test_plugins.py
+++ b/aldryn_faq/tests/test_plugins.py
@@ -42,7 +42,7 @@ class TestQuestionListPlugin(AldrynFaqTest):
             page1, self.user, None, lang_code="en", edit=False)
         context = RequestContext(request, {})
         rendered = plugin.render_plugin(context, ph)
-        self.assertTrue(rendered.find(">No entry found.</p>") > -1)
+        self.assertTrue(rendered.find("No entry found.") > -1)
 
         # Now, add a question, and test that it renders.
         question1 = self.reload(self.question1, "en")

--- a/test_settings.py
+++ b/test_settings.py
@@ -68,7 +68,6 @@ HELPER_SETTINGS = {
         'cms.middleware.toolbar.ToolbarMiddleware',
         'cms.middleware.language.LanguageCookieMiddleware'
     ],
-    'ALDRYN_BOILERPLATE_NAME': 'bootstrap3',
     'HAYSTACK_CONNECTIONS': HAYSTACK_CONNECTIONS,
     'PARLER_LANGUAGES': {
         1: (
@@ -121,7 +120,7 @@ if cms_version < LooseVersion('3.2.0'):
 
 def run():
     from djangocms_helper import runner
-    runner.cms('aldryn_faq', extra_args=['--boilerplate'])
+    runner.cms('aldryn_faq', extra_args=[])
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
The goal of this Pull Request is:

- Simplify template structure
- Remove unnecessary placeholder and blocks
- In general make everything simple for easier explanation

We also want to remove ``render_placeholder view.config`` and later only mention it in the documentation (separate PR will follow).