### PR TITLE
Bump django-sortedm2m version. Set up toxworkdir to homedir.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ REQUIREMENTS = [
     'djangocms-text-ckeditor',
     'django-parler>=1.4,<1.7',
     'django-reversion>=1.8.2,<1.11',
-    'django-sortedm2m',
+    'django-sortedm2m>=1.2.2',
 
     # THIS IS HERE TO SUPPORT EXISTING MIGRATIONS AND CAN BE REMOVED ONLY ONCE
     # WE NO LONGER SUPPORT SOUTH MIGRATIONS.

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+toxworkdir = {homedir}/.toxenvs/aldryn-faq
 envlist =
     flake8
     py{34,27}-dj19-cms32


### PR DESCRIPTION
Setting up ``toxworkdir`` to homedir. this will add some preformance for test env setup.